### PR TITLE
Stabilize tests: disable xUnit parallelization and manage Vitest timers/globals

### DIFF
--- a/BoardOil.Api.Tests/AssemblyInfo.cs
+++ b/BoardOil.Api.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/BoardOil.Web/src/realtime/boardRealtime.test.ts
+++ b/BoardOil.Web/src/realtime/boardRealtime.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type TypingChangedHandler = (event: { cardId: number; isTyping: boolean; userLabel: string }) => void;
 
@@ -71,7 +71,7 @@ function makeLocalStorage(userLabel = 'Me') {
 
 describe('boardRealtime', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.resetModules();
     vi.stubGlobal('window', {
@@ -102,7 +102,13 @@ describe('boardRealtime', () => {
     expect(onResync).toHaveBeenCalledTimes(1);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
   it('resets typing timeout during churn and sends one stop for latest timer', async () => {
+    vi.useFakeTimers();
     const { createBoardRealtime } = await import('./boardRealtime');
     const realtime = createBoardRealtime({
       onColumnCreated: vi.fn(),


### PR DESCRIPTION
### Motivation
- Tests for realtime behavior were flaky due to shared global state and timer interactions across test runs, and xUnit parallelization could cause cross-test interference.

### Description
- Add `BoardOil.Api.Tests/AssemblyInfo.cs` to disable xUnit test parallelization via `[assembly: CollectionBehavior(DisableTestParallelization = true)]`.
- Update `BoardOil.Web/src/realtime/boardRealtime.test.ts` to import `afterEach` and switch the default test environment to `vi.useRealTimers()` in `beforeEach` to avoid global fake-timer leakage.
- Scope `vi.useFakeTimers()` to the specific test that needs it and add an `afterEach` that calls `vi.useRealTimers()` and `vi.unstubAllGlobals()` to clean up globals such as `window` and `localStorage` between tests.
- Ensure pending timer tasks are awaited with `vi.runOnlyPendingTimersAsync()` when using fake timers to make timer-based assertions reliable.

### Testing
- Ran API unit tests with `dotnet test`, which completed successfully.
- Ran frontend tests with `vitest`, which completed successfully and stabilized the previously flaky `boardRealtime` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4ae97fac8321885109dded988132)