### PR TITLE
Add nightly docker publish workflow

### DIFF
--- a/.github/workflows/publish-image-nightly.yml
+++ b/.github/workflows/publish-image-nightly.yml
@@ -1,0 +1,87 @@
+name: Publish Nightly Docker Image
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: publish-image-nightly
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and Publish Nightly to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute image name
+        id: image
+        run: |
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
+          echo "name=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect changes since last nightly build
+        id: changes
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          LAST_SHA="$(git rev-list -n 1 refs/tags/nightly-last-build 2>/dev/null || true)"
+
+          echo "current_sha=${CURRENT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$CURRENT_SHA" ]; then
+            echo "No changes since last nightly build (${CURRENT_SHA}). Skipping publish."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            if [ -z "$LAST_SHA" ]; then
+              echo "No previous nightly marker found. Publishing nightly image."
+            else
+              echo "Detected changes since last nightly build (${LAST_SHA} -> ${CURRENT_SHA})."
+            fi
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        if: steps.changes.outputs.should_build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        if: steps.changes.outputs.should_build == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=nightly-${{ steps.changes.outputs.short_sha }}
+
+      - name: Build and push image
+        if: steps.changes.outputs.should_build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update nightly build marker tag
+        if: steps.changes.outputs.should_build == 'true'
+        run: |
+          git tag -f nightly-last-build "${{ steps.changes.outputs.current_sha }}"
+          git push origin refs/tags/nightly-last-build --force


### PR DESCRIPTION
## Summary
- add nightly Docker publish workflow
- publish only when `main` has changed since last nightly build marker
- push tags `nightly` and `nightly-<shortsha>`
- keep `latest` untouched

## Notes
- workflow also supports manual dispatch
- updates `nightly-last-build` tag after successful publish
