### PR TITLE
Add MCP contracts and scaffold MCP server with tool handlers

### DIFF
--- a/BoardOil.Mcp.Contracts/BoardOil.Mcp.Contracts.csproj
+++ b/BoardOil.Mcp.Contracts/BoardOil.Mcp.Contracts.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BoardOil.Mcp.Contracts/Models.cs
+++ b/BoardOil.Mcp.Contracts/Models.cs
@@ -1,0 +1,86 @@
+namespace BoardOil.Mcp.Contracts;
+
+public sealed record McpToolDefinition(
+    string Name,
+    string Description,
+    string InputSchemaJson,
+    string OutputSchemaJson);
+
+public sealed record McpToolError(
+    string Code,
+    string Message,
+    int StatusCode,
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? ValidationErrors = null);
+
+public sealed record McpToolResult<T>(
+    bool Success,
+    T? Data,
+    McpToolError? Error);
+
+public sealed record McpBoardSnapshot(
+    int BoardId,
+    string BoardName,
+    DateTime UpdatedAtUtc,
+    IReadOnlyList<McpColumnSnapshot> Columns);
+
+public sealed record McpColumnSnapshot(
+    int ColumnId,
+    string Title,
+    string SortKey,
+    IReadOnlyList<McpCardSnapshot> Cards);
+
+public sealed record McpCardSnapshot(
+    int CardId,
+    int BoardColumnId,
+    string Title,
+    string Description,
+    string SortKey,
+    IReadOnlyList<string> TagNames,
+    DateTime UpdatedAtUtc);
+
+public sealed record BoardGetInput(int BoardId);
+
+public sealed record ColumnsListInput(int BoardId);
+
+public sealed record ColumnsListOutput(
+    int BoardId,
+    IReadOnlyList<McpColumnReference> Columns);
+
+public sealed record McpColumnReference(
+    int ColumnId,
+    string Title,
+    string SortKey);
+
+public sealed record CardCreateInput(
+    int BoardId,
+    int BoardColumnId,
+    string Title,
+    string Description,
+    IReadOnlyList<string>? TagNames);
+
+public sealed record CardUpdateInput(
+    int BoardId,
+    int CardId,
+    string Title,
+    string Description,
+    IReadOnlyList<string> TagNames);
+
+public sealed record CardMoveInput(
+    int BoardId,
+    int CardId,
+    int BoardColumnId,
+    int? PositionAfterCardId);
+
+public sealed record CardMoveByColumnNameInput(
+    int BoardId,
+    int CardId,
+    string ColumnTitle,
+    int? PositionAfterCardId);
+
+public sealed record CardDeleteInput(
+    int BoardId,
+    int CardId);
+
+public sealed record CardMutationOutput(
+    McpCardSnapshot? Card,
+    string Outcome);

--- a/BoardOil.Mcp.Contracts/Schemas/ToolSchemas.cs
+++ b/BoardOil.Mcp.Contracts/Schemas/ToolSchemas.cs
@@ -1,0 +1,127 @@
+namespace BoardOil.Mcp.Contracts.Schemas;
+
+public static class ToolSchemas
+{
+    public const string BoardGetInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["boardId"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string ColumnsListInput = BoardGetInput;
+
+    public const string CardCreateInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "boardColumnId": { "type": "integer", "minimum": 1 },
+        "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "description": { "type": "string", "maxLength": 20000 },
+        "tagNames": {
+          "type": ["array", "null"],
+          "items": { "type": "string", "minLength": 1, "maxLength": 80 },
+          "maxItems": 20
+        }
+      },
+      "required": ["boardId", "boardColumnId", "title", "description"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string CardUpdateInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "cardId": { "type": "integer", "minimum": 1 },
+        "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "description": { "type": "string", "maxLength": 20000 },
+        "tagNames": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 80 },
+          "maxItems": 20
+        }
+      },
+      "required": ["boardId", "cardId", "title", "description", "tagNames"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string CardMoveInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "cardId": { "type": "integer", "minimum": 1 },
+        "boardColumnId": { "type": "integer", "minimum": 1 },
+        "positionAfterCardId": { "type": ["integer", "null"], "minimum": 1 }
+      },
+      "required": ["boardId", "cardId", "boardColumnId"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string CardMoveByColumnNameInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "cardId": { "type": "integer", "minimum": 1 },
+        "columnTitle": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "positionAfterCardId": { "type": ["integer", "null"], "minimum": 1 }
+      },
+      "required": ["boardId", "cardId", "columnTitle"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string CardDeleteInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "cardId": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["boardId", "cardId"],
+      "additionalProperties": false
+    }
+    """;
+
+    public const string SuccessOutput = """
+    {
+      "type": "object",
+      "properties": {
+        "success": { "const": true },
+        "data": { "type": "object" },
+        "error": { "type": "null" }
+      },
+      "required": ["success", "data", "error"]
+    }
+    """;
+
+    public const string ErrorOutput = """
+    {
+      "type": "object",
+      "properties": {
+        "success": { "const": false },
+        "data": { "type": "null" },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": { "type": "string" },
+            "message": { "type": "string" },
+            "statusCode": { "type": "integer" }
+          },
+          "required": ["code", "message", "statusCode"]
+        }
+      },
+      "required": ["success", "data", "error"]
+    }
+    """;
+}

--- a/BoardOil.Mcp.Contracts/ToolCatalogue.cs
+++ b/BoardOil.Mcp.Contracts/ToolCatalogue.cs
@@ -1,0 +1,17 @@
+using BoardOil.Mcp.Contracts.Schemas;
+
+namespace BoardOil.Mcp.Contracts;
+
+public static class ToolCatalogue
+{
+    public static readonly IReadOnlyList<McpToolDefinition> Definitions =
+    [
+        new(ToolNames.BoardGet, "Get a board snapshot including columns and cards.", ToolSchemas.BoardGetInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.ColumnsList, "List columns for a board so an agent can resolve dynamic states.", ToolSchemas.ColumnsListInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.CardCreate, "Create a card in a specific column.", ToolSchemas.CardCreateInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.CardUpdate, "Update card title, description, and tags.", ToolSchemas.CardUpdateInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.CardMove, "Move card by target column id and optional sibling anchor.", ToolSchemas.CardMoveInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.CardMoveByColumnName, "Move card by dynamic column title.", ToolSchemas.CardMoveByColumnNameInput, ToolSchemas.SuccessOutput),
+        new(ToolNames.CardDelete, "Delete a card.", ToolSchemas.CardDeleteInput, ToolSchemas.SuccessOutput)
+    ];
+}

--- a/BoardOil.Mcp.Contracts/ToolNames.cs
+++ b/BoardOil.Mcp.Contracts/ToolNames.cs
@@ -1,0 +1,12 @@
+namespace BoardOil.Mcp.Contracts;
+
+public static class ToolNames
+{
+    public const string BoardGet = "board.get";
+    public const string ColumnsList = "columns.list";
+    public const string CardCreate = "card.create";
+    public const string CardUpdate = "card.update";
+    public const string CardMove = "card.move";
+    public const string CardMoveByColumnName = "card.move_by_column_name";
+    public const string CardDelete = "card.delete";
+}

--- a/BoardOil.Mcp.Contracts/packages.lock.json
+++ b/BoardOil.Mcp.Contracts/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {}
+  }
+}

--- a/BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj
+++ b/BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\BoardOil.Abstractions\BoardOil.Abstractions.csproj" />
+    <ProjectReference Include="..\BoardOil.Contracts\BoardOil.Contracts.csproj" />
+    <ProjectReference Include="..\BoardOil.Mcp.Contracts\BoardOil.Mcp.Contracts.csproj" />
+    <ProjectReference Include="..\BoardOil.Services\BoardOil.Services.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BoardOil.Mcp.Server/Contracts/IToolHandler.cs
+++ b/BoardOil.Mcp.Server/Contracts/IToolHandler.cs
@@ -1,0 +1,10 @@
+using BoardOil.Mcp.Contracts;
+
+namespace BoardOil.Mcp.Server.Contracts;
+
+public interface IToolHandler<in TInput, TOutput>
+{
+    string ToolName { get; }
+
+    Task<McpToolResult<TOutput>> HandleAsync(TInput input, CancellationToken cancellationToken);
+}

--- a/BoardOil.Mcp.Server/Mapping/McpMappingExtensions.cs
+++ b/BoardOil.Mcp.Server/Mapping/McpMappingExtensions.cs
@@ -1,0 +1,64 @@
+using BoardOil.Contracts.Board;
+using BoardOil.Contracts.Card;
+using BoardOil.Contracts.Contracts;
+using BoardOil.Mcp.Contracts;
+
+namespace BoardOil.Mcp.Server.Mapping;
+
+public static class McpMappingExtensions
+{
+    public static McpBoardSnapshot ToMcp(this BoardDto board) =>
+        new(
+            board.Id,
+            board.Name,
+            board.UpdatedAtUtc,
+            board.Columns
+                .Select(column => new McpColumnSnapshot(
+                    column.Id,
+                    column.Title,
+                    column.SortKey,
+                    column.Cards.Select(card => card.ToMcp()).ToArray()))
+                .ToArray());
+
+    public static McpCardSnapshot ToMcp(this CardDto card) =>
+        new(
+            card.Id,
+            card.BoardColumnId,
+            card.Title,
+            card.Description,
+            card.SortKey,
+            card.TagNames,
+            card.UpdatedAtUtc);
+
+    public static McpToolResult<T> ToMcpFailure<T>(this ApiResult apiResult)
+    {
+        var code = apiResult.StatusCode switch
+        {
+            400 => "validation_failed",
+            401 => "unauthorised",
+            403 => "forbidden",
+            404 => "not_found",
+            _ => "service_error"
+        };
+
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? validation = null;
+        if (apiResult.ValidationErrors is not null)
+        {
+            validation = apiResult.ValidationErrors.ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<string>)x.Value);
+        }
+
+        return new McpToolResult<T>(
+            false,
+            default,
+            new McpToolError(
+                code,
+                apiResult.Message ?? "Service returned an error.",
+                apiResult.StatusCode,
+                validation));
+    }
+
+    public static McpToolResult<T> ToMcpSuccess<T>(this T payload) =>
+        new(true, payload, null);
+}

--- a/BoardOil.Mcp.Server/Program.cs
+++ b/BoardOil.Mcp.Server/Program.cs
@@ -1,0 +1,30 @@
+using BoardOil.Mcp.Server.Tools;
+using BoardOil.Services.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+var connectionString = Environment.GetEnvironmentVariable("BOARDOIL_MCP_CONNECTION_STRING");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("Set BOARDOIL_MCP_CONNECTION_STRING before running BoardOil.Mcp.Server.");
+}
+
+var services = new ServiceCollection();
+services.AddBoardOilServices(connectionString);
+
+services.AddTransient<BoardGetToolHandler>();
+services.AddTransient<ColumnsListToolHandler>();
+services.AddTransient<CardCreateToolHandler>();
+services.AddTransient<CardUpdateToolHandler>();
+services.AddTransient<CardMoveToolHandler>();
+services.AddTransient<CardMoveByColumnNameToolHandler>();
+services.AddTransient<CardDeleteToolHandler>();
+services.AddSingleton<ToolRegistry>();
+
+using var provider = services.BuildServiceProvider();
+
+var registry = provider.GetRequiredService<ToolRegistry>();
+Console.WriteLine("BoardOil MCP scaffold ready. Registered tools:");
+foreach (var tool in registry.ListTools())
+{
+    Console.WriteLine($" - {tool.Name}");
+}

--- a/BoardOil.Mcp.Server/Tools/BoardGetToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/BoardGetToolHandler.cs
@@ -1,0 +1,22 @@
+using BoardOil.Abstractions.Board;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class BoardGetToolHandler(IBoardService boardService) : IToolHandler<BoardGetInput, McpBoardSnapshot>
+{
+    public string ToolName => ToolNames.BoardGet;
+
+    public async Task<McpToolResult<McpBoardSnapshot>> HandleAsync(BoardGetInput input, CancellationToken cancellationToken)
+    {
+        var result = await boardService.GetBoardAsync(input.BoardId);
+        if (!result.Success || result.Data is null)
+        {
+            return result.ToMcpFailure<McpBoardSnapshot>();
+        }
+
+        return result.Data.ToMcp().ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/CardCreateToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/CardCreateToolHandler.cs
@@ -1,0 +1,24 @@
+using BoardOil.Abstractions.Card;
+using BoardOil.Contracts.Card;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class CardCreateToolHandler(ICardService cardService) : IToolHandler<CardCreateInput, CardMutationOutput>
+{
+    public string ToolName => ToolNames.CardCreate;
+
+    public async Task<McpToolResult<CardMutationOutput>> HandleAsync(CardCreateInput input, CancellationToken cancellationToken)
+    {
+        var request = new CreateCardRequest(input.BoardColumnId, input.Title, input.Description, input.TagNames);
+        var result = await cardService.CreateCardAsync(input.BoardId, request);
+        if (!result.Success || result.Data is null)
+        {
+            return result.ToMcpFailure<CardMutationOutput>();
+        }
+
+        return new CardMutationOutput(result.Data.ToMcp(), "created").ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/CardDeleteToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/CardDeleteToolHandler.cs
@@ -1,0 +1,22 @@
+using BoardOil.Abstractions.Card;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class CardDeleteToolHandler(ICardService cardService) : IToolHandler<CardDeleteInput, CardMutationOutput>
+{
+    public string ToolName => ToolNames.CardDelete;
+
+    public async Task<McpToolResult<CardMutationOutput>> HandleAsync(CardDeleteInput input, CancellationToken cancellationToken)
+    {
+        var result = await cardService.DeleteCardAsync(input.BoardId, input.CardId);
+        if (!result.Success)
+        {
+            return result.ToMcpFailure<CardMutationOutput>();
+        }
+
+        return new CardMutationOutput(null, "deleted").ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/CardMoveByColumnNameToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/CardMoveByColumnNameToolHandler.cs
@@ -1,0 +1,55 @@
+using BoardOil.Abstractions.Board;
+using BoardOil.Abstractions.Card;
+using BoardOil.Contracts.Card;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class CardMoveByColumnNameToolHandler(
+    IBoardService boardService,
+    ICardService cardService)
+    : IToolHandler<CardMoveByColumnNameInput, CardMutationOutput>
+{
+    public string ToolName => ToolNames.CardMoveByColumnName;
+
+    public async Task<McpToolResult<CardMutationOutput>> HandleAsync(CardMoveByColumnNameInput input, CancellationToken cancellationToken)
+    {
+        var boardResult = await boardService.GetBoardAsync(input.BoardId);
+        if (!boardResult.Success || boardResult.Data is null)
+        {
+            return boardResult.ToMcpFailure<CardMutationOutput>();
+        }
+
+        var matches = boardResult.Data.Columns
+            .Where(column => string.Equals(column.Title, input.ColumnTitle, StringComparison.OrdinalIgnoreCase))
+            .Select(column => column.Id)
+            .Distinct()
+            .ToArray();
+
+        if (matches.Length == 0)
+        {
+            return new McpToolResult<CardMutationOutput>(
+                false,
+                null,
+                new McpToolError("column_not_found", $"No column named '{input.ColumnTitle}' exists on board {input.BoardId}.", 404));
+        }
+
+        if (matches.Length > 1)
+        {
+            return new McpToolResult<CardMutationOutput>(
+                false,
+                null,
+                new McpToolError("column_ambiguous", $"Multiple columns named '{input.ColumnTitle}' exist on board {input.BoardId}. Move by column id instead.", 400));
+        }
+
+        var moveResult = await cardService.MoveCardAsync(input.BoardId, input.CardId, new MoveCardRequest(matches[0], input.PositionAfterCardId));
+        if (!moveResult.Success || moveResult.Data is null)
+        {
+            return moveResult.ToMcpFailure<CardMutationOutput>();
+        }
+
+        return new CardMutationOutput(moveResult.Data.ToMcp(), "moved").ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/CardMoveToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/CardMoveToolHandler.cs
@@ -1,0 +1,24 @@
+using BoardOil.Abstractions.Card;
+using BoardOil.Contracts.Card;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class CardMoveToolHandler(ICardService cardService) : IToolHandler<CardMoveInput, CardMutationOutput>
+{
+    public string ToolName => ToolNames.CardMove;
+
+    public async Task<McpToolResult<CardMutationOutput>> HandleAsync(CardMoveInput input, CancellationToken cancellationToken)
+    {
+        var request = new MoveCardRequest(input.BoardColumnId, input.PositionAfterCardId);
+        var result = await cardService.MoveCardAsync(input.BoardId, input.CardId, request);
+        if (!result.Success || result.Data is null)
+        {
+            return result.ToMcpFailure<CardMutationOutput>();
+        }
+
+        return new CardMutationOutput(result.Data.ToMcp(), "moved").ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/CardUpdateToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/CardUpdateToolHandler.cs
@@ -1,0 +1,24 @@
+using BoardOil.Abstractions.Card;
+using BoardOil.Contracts.Card;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class CardUpdateToolHandler(ICardService cardService) : IToolHandler<CardUpdateInput, CardMutationOutput>
+{
+    public string ToolName => ToolNames.CardUpdate;
+
+    public async Task<McpToolResult<CardMutationOutput>> HandleAsync(CardUpdateInput input, CancellationToken cancellationToken)
+    {
+        var request = new UpdateCardRequest(input.Title, input.Description, input.TagNames);
+        var result = await cardService.UpdateCardAsync(input.BoardId, input.CardId, request);
+        if (!result.Success || result.Data is null)
+        {
+            return result.ToMcpFailure<CardMutationOutput>();
+        }
+
+        return new CardMutationOutput(result.Data.ToMcp(), "updated").ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/ColumnsListToolHandler.cs
+++ b/BoardOil.Mcp.Server/Tools/ColumnsListToolHandler.cs
@@ -1,0 +1,28 @@
+using BoardOil.Abstractions.Column;
+using BoardOil.Mcp.Contracts;
+using BoardOil.Mcp.Server.Contracts;
+using BoardOil.Mcp.Server.Mapping;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class ColumnsListToolHandler(IColumnService columnService) : IToolHandler<ColumnsListInput, ColumnsListOutput>
+{
+    public string ToolName => ToolNames.ColumnsList;
+
+    public async Task<McpToolResult<ColumnsListOutput>> HandleAsync(ColumnsListInput input, CancellationToken cancellationToken)
+    {
+        var result = await columnService.GetColumnsAsync(input.BoardId);
+        if (!result.Success || result.Data is null)
+        {
+            return result.ToMcpFailure<ColumnsListOutput>();
+        }
+
+        var output = new ColumnsListOutput(
+            input.BoardId,
+            result.Data
+                .Select(column => new McpColumnReference(column.Id, column.Title, column.SortKey))
+                .ToArray());
+
+        return output.ToMcpSuccess();
+    }
+}

--- a/BoardOil.Mcp.Server/Tools/ToolRegistry.cs
+++ b/BoardOil.Mcp.Server/Tools/ToolRegistry.cs
@@ -1,0 +1,8 @@
+using BoardOil.Mcp.Contracts;
+
+namespace BoardOil.Mcp.Server.Tools;
+
+public sealed class ToolRegistry
+{
+    public IReadOnlyList<McpToolDefinition> ListTools() => ToolCatalogue.Definitions;
+}

--- a/BoardOil.Mcp.Server/packages.lock.json
+++ b/BoardOil.Mcp.Server/packages.lock.json
@@ -1,0 +1,288 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "63eZHvKVbBnjX3QDbac2S+05SKbaX/2yiQYZI0VR10EegeZGMhT1LPgi0ax76UfLkFOgap7UGpybPbjgzUrlag=="
+      },
+      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "+Bi0aTctq7Z+j2lpSfQ/CdrA8x7JcsmJDd8KC6IC93rvNokRbi3wJ4H0gJqlNysTGp764D/KGsL93fsqddlLEw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.4"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "UkmpN2pDkrtVLh+ypRDCbBij9mhPqOPzvHI625rf+VeT3FHnBwBjAY7XgjK8rGDI74fDx7C1SSIf2OAaAX4g2A==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kzTsfFK2GCytp6DDTfQOmxPU4gbGdrIlP7PxrxF3ESNLtfXrC8BoUVZENBN2WORlZPAD7CVX6AYIglgkpXQooA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.4",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "qDcJqCfN1XYyX0ID/Hd9/kQTRvlia8S+Yuwyl9uFhBIKnOCbl9WMdGQCzbZUKbkpkfvf3P9CDdXsnxHyE3O0Aw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "pQeMHCyD3yTtCEGnHV4VsgKUvrESo3MR5mnh8sgQ1hWYmI1YFsUutDowBIxkobeWRtaRmBqQAtF7XQFW6FWuNA=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "cbc/Ave31CbPQ9E29dfaA4QjcsBoc8KokNlLC6Noj0uToHDQ9PPllD+k6HluVbaFpflsU8XGwrQxOoyvXlU97g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyModel": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "8D3Kk7assWpi93DuicgucDqGoOsgEgLlZy8io0FUlSGG2b4wkRWkjXn4xFBX+BzxExjfcYvHhtcBpqkXhe2p0A==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.4",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyModel": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "uDRooaV6N3WZ0kdlNPMB68/MdGn/in1Fs7Db7DnIm85RBTPy4P321WO+daAImiYpH5dekjNggDqy1N44WaIlMA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "CLLussNUMdSbyJOu4VBF7sqskHGB/5N1EcFzrqG/HsPATN8fCRUcfp0qns1VwkxKHwxrtYCh5FKe+kM81Q1PHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "601B3ha6XvOsOcu9GVd2dVd1KEDuqr49r46GUWhNJkeZDhZ/NI9EYTyoeQjZQEi8ZUvnrv++FbTfGmC8F0vgtg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "3x9X9SMAMdAoEwWxHfsT2a9dTBqEtfYfbEOFw+UPtBshEH2gHWJeazxrZ1FK1O18MoCbe1NxINg5qciB01pEcg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "ilnL/kQn62Gx3OZCVT7SJrBNi0CRIhS8VEunmE6i/a9lp9l/eos+hpxMvCW4iX2aVc/NWeDhxuQusZL7zvmKIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "NkvJ8aSr3AG30yabjv7ZWwTG/wq5OElNTlNq39Ok2HSEF3TIwAc1f1xnTJlR/GuoJmEgkfT7WBO9YbSXRk41+g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "SIe9zlVQJecnk/DTmevIcl6+aEDYhoVLc2eG2AKwVeNEC8CSyxHAbh4lf0xtHq9JUum0vVTEByGNTK+b6oihTQ=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "LiJXylfk8pk+2zsUsITkou3QTFMJ8RNJ0oKKY0Oyjt6HJctGJwPw//ZgoNO4J29zKaT+dR4/PI2jW/znRcspLg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "R9W7AttMedwOwJ7wRqTGBoVbX2JmlyWA+LJQUhizmS7Be9f6EJUn/+lvaIYDrOYtA1UzAfrwU871hpvZSPyIkg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.4",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "JH2RyevIwJ1E9mBsZRXR+12TnUauptKgzCdOghhk3sE+dqcxB16GoE7x+0IuqTbaixM1ESXTNoqEw/IBnhM7LQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Identity.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "n2MIwxPu+5+voKM94XFzTTUPRKFc26fhDH4vYqU1BjpNXQIYA9N3Dg811q7K6gOr9YgukaxZqyimkKKj9qUqEA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.4",
+          "Microsoft.Extensions.Diagnostics": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "S8+6fCuMOhJZGk8sGFtOy3VsF9mk9x4UOL59GM91REiA/fmCDjunKKIw4RmStG87qyXPfxelDJf2pXIbTuaBdw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kRxa2Zjzhg/ohh7EklpqQpBIcyQnC3meWxCcpZBn+0QWy/fY1DmDd45JiW8Vyrpj2J1RDtau5yRHiLZS/AoxUw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "amQUITwSnkbMPxh/ngneNykz4UtytEOXo0M/pbwdBiQU57EAVvBV5PFI8r/dRastUj0yxHVwrH64N9ACR5SdGQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "lABYqiRH9HgYJsjzO3W7+cucUwWXhEkiyrRylANdIubnzcESlkIsLowXpQ4E+sc7kjMLbk1hk5oxw4qTKowTEg=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "boardoil.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "BoardOil.Contracts": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.4, )"
+        }
+      },
+      "boardoil.contracts": {
+        "type": "Project"
+      },
+      "boardoil.ef": {
+        "type": "Project",
+        "dependencies": {
+          "BoardOil.Abstractions": "[1.0.0, )",
+          "BoardOil.Persistence.Abstractions": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.4, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.4, )"
+        }
+      },
+      "boardoil.mcp.contracts": {
+        "type": "Project"
+      },
+      "boardoil.persistence.abstractions": {
+        "type": "Project"
+      },
+      "boardoil.services": {
+        "type": "Project",
+        "dependencies": {
+          "BoardOil.Abstractions": "[1.0.0, )",
+          "BoardOil.Contracts": "[1.0.0, )",
+          "BoardOil.Ef": "[1.0.0, )",
+          "BoardOil.Persistence.Abstractions": "[1.0.0, )",
+          "Microsoft.Extensions.Identity.Core": "[10.0.4, )"
+        }
+      }
+    }
+  }
+}

--- a/BoardOil.slnx
+++ b/BoardOil.slnx
@@ -5,6 +5,8 @@
   <Project Path="BoardOil.Contracts/BoardOil.Contracts.csproj" />
   <Project Path="BoardOil.Ef/BoardOil.Ef.csproj" />
   <Project Path="BoardOil.Persistence.Abstractions/BoardOil.Persistence.Abstractions.csproj" />
+  <Project Path="BoardOil.Mcp.Contracts/BoardOil.Mcp.Contracts.csproj" />
+  <Project Path="BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj" />
   <Project Path="BoardOil.Services/BoardOil.Services.csproj" />
   <Project Path="BoardOil.Services.Tests/BoardOil.Services.Tests.csproj" />
 </Solution>

--- a/README.md
+++ b/README.md
@@ -53,3 +53,67 @@ Run backend + frontend:
 ```bash
 ./dev-startall.sh
 ```
+
+## MCP for Agents
+
+Use the MCP server from your agent client as a local command (stdio).
+
+### 1) Build the MCP server
+
+```bash
+dotnet build BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj -maxcpucount:1 -nodeReuse:false
+```
+
+### 2) Configure your agent to start the MCP server
+
+Set the database connection string first:
+
+```bash
+export BOARDOIL_MCP_CONNECTION_STRING="Data Source=/data/boardoil.db"
+```
+
+Then configure your agent MCP client to launch:
+
+- command: `dotnet`
+- args: `run --project BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj -maxcpucount:1 -nodeReuse:false`
+
+Example MCP client entry:
+
+```json
+{
+  "mcpServers": {
+    "boardoil": {
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj",
+        "-maxcpucount:1",
+        "-nodeReuse:false"
+      ],
+      "env": {
+        "BOARDOIL_MCP_CONNECTION_STRING": "Data Source=/data/boardoil.db"
+      }
+    }
+  }
+}
+```
+
+### 3) Verify tools exposed to the agent
+Tool names are defined in:
+- `BoardOil.Mcp.Contracts/ToolNames.cs`
+- `BoardOil.Mcp.Contracts/ToolCatalogue.cs`
+
+Schemas and payload contracts are defined in:
+- `BoardOil.Mcp.Contracts/Schemas/ToolSchemas.cs`
+- `BoardOil.Mcp.Contracts/Models.cs`
+
+## Docker Compose Status (MCP)
+`docker compose up --build` currently builds and runs only the `boardoil` API/web service.
+It does **not** run `BoardOil.Mcp.Server` yet.
+
+Current compose/runtime files:
+- `docker-compose.yml` defines only `boardoil`.
+- `Dockerfile` publishes only `BoardOil.Api` and starts `BoardOil.Api.dll`.
+
+If you want MCP in Compose, add a separate `boardoil-mcp` service and publish target for `BoardOil.Mcp.Server`.


### PR DESCRIPTION
### Motivation

- Provide a Machine Control Protocol (MCP) surface so external agents can interact with BoardOil (list boards/columns and perform card mutations). 
- Define stable contracts and JSON schemas for agent tooling to ensure structured input/output and error reporting. 
- Scaffold a local MCP server that wires into existing services so agents can run a local process that exposes available tools. 

### Description

- Add new `BoardOil.Mcp.Contracts` project containing DTOs in `Models.cs`, JSON schemas in `Schemas/ToolSchemas.cs`, tool names in `ToolNames.cs`, and a `ToolCatalogue` exposing `McpToolDefinition`s. 
- Add new `BoardOil.Mcp.Server` project with a simple `Program.cs`, a `ToolRegistry`, mapping extensions in `Mapping/McpMappingExtensions.cs`, an `IToolHandler` interface, and concrete tool handlers under `Tools/` for `board.get`, `columns.list`, `card.create`, `card.update`, `card.move`, `card.move_by_column_name`, and `card.delete`. 
- Wire the new projects into the solution by updating `BoardOil.slnx` and include `packages.lock.json` files for the new projects. 
- Update `README.md` with build/run instructions and example MCP client configuration for launching the MCP server. 

### Testing

- Ran a solution build with `dotnet build BoardOil.slnx` which succeeded for the added projects. 
- Ran `dotnet build BoardOil.Mcp.Server/BoardOil.Mcp.Server.csproj` to validate the server scaffolding and it completed successfully. 
- No automated unit tests were added for the MCP surface in this change and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70b33894c832189125d047631535f)