### PR TITLE
Add shared entity-row styles and migrate management views to use them

### DIFF
--- a/AGENTS/Frontend.md
+++ b/AGENTS/Frontend.md
@@ -35,6 +35,13 @@ BoardOil frontend state uses Pinia stores with a small set of focused stores:
 - Prefer `.btn.btn--tab` for tab toggles.
 - Prefer `.btn.btn--toolbar` for markdown toolbar actions/mode toggles.
 - Prefer `.btn.btn--menu-item` for menu-panel button actions.
+- For management/list pages with repeated row patterns (for example Boards/Tags/Users/Columns manager views), use the shared entity-row styles in `BoardOil.Web/src/styles/entity-rows.css`:
+  - page shell: `.entity-rows-page` (or `.entity-rows-page--compact` for narrower pages)
+  - list container: `.entity-rows-list`
+  - row container: `.entity-row`
+  - row content/action slots: `.entity-row-main`, `.entity-row-actions`
+  - row title/badge helpers: `.entity-row-title`, `.entity-row-badges`, `.entity-row-action-icon`
+- Keep this entity-row pattern as the default for new management-style rows; only add view-specific row classes when behaviour or visuals are genuinely unique.
 - Keep shared/global classes in shared stylesheets (`BoardOil.Web/src/style.css`, `BoardOil.Web/src/styles/*.css`) only when they are reused across views/components or define app-wide layout/theme behavior.
 - Keep page-specific/component-specific classes in the relevant Vue file (`<style scoped>`), not in global stylesheets.
 - Keep non-`.btn` controls limited to intentional interaction widgets:

--- a/BoardOil.Web/src/style.css
+++ b/BoardOil.Web/src/style.css
@@ -1,4 +1,5 @@
 @import "./styles/buttons.css";
+@import "./styles/entity-rows.css";
 
 @font-face {
   font-family: "Montserrat";
@@ -653,93 +654,6 @@ body {
   gap: 0.35rem;
 }
 
-.columns-manager-toolbar {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-}
-
-.column-manager {
-  margin-top: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  max-width: 56rem;
-}
-
-.column-manager-item {
-  background: var(--bo-surface-panel);
-  border: 1px solid var(--bo-border-soft);
-  border-radius: 12px;
-  padding: 0.75rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.create-column-inline {
-  border-style: dashed;
-}
-
-.column-create-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.35rem;
-}
-
-.column-manager-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.column-manager-title {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.column-manager-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.column-drag-handle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  padding: 0.35rem 0.45rem;
-  border: 1px solid var(--bo-border-default);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--bo-link);
-  cursor: grab;
-  user-select: none;
-}
-
-.column-drag-handle:hover {
-  background: var(--bo-surface-energy);
-  border-color: var(--bo-colour-energy);
-  color: var(--bo-colour-energy);
-}
-
-.column-drag-handle:active {
-  cursor: grabbing;
-}
-
-.draggable-column.drag-over {
-  border-color: var(--bo-colour-secondary);
-  box-shadow: 0 0 0 2px rgba(105, 193, 206, 0.28);
-}
-
-.column-manager-item label {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-  color: var(--bo-ink-default);
-}
 
 .card {
   border: 1px solid var(--bo-border-soft);
@@ -961,159 +875,6 @@ select:focus {
   margin: 0;
 }
 
-.users-manager {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-  max-width: 760px;
-}
-
-.boards-view {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-  max-width: 860px;
-  padding: 0 1.5rem;
-}
-
-.boards-header h2 {
-  margin: 0;
-}
-
-.boards-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.boards-header > .btn {
-  flex: 0 0 auto;
-}
-
-.boards-empty {
-  margin: 0;
-  color: var(--bo-ink-muted);
-}
-
-.boards-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.55rem;
-}
-
-.boards-item {
-  list-style: none;
-}
-
-.boards-row {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-}
-
-.boards-open {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.6rem;
-  text-align: left;
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid var(--bo-border-soft);
-  background: var(--bo-surface-panel);
-  color: var(--bo-ink-strong);
-  flex: 1 1 auto;
-}
-
-.boards-open:hover:not(:disabled),
-.boards-open:focus-visible {
-  border-color: var(--bo-colour-energy);
-  background: var(--bo-surface-energy);
-  color: var(--bo-colour-energy);
-}
-
-.boards-name {
-  font-weight: 700;
-}
-
-.boards-meta {
-  flex: 0 0 auto;
-}
-
-.boards-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-}
-
-.boards-action-icon {
-  min-width: 2.35rem;
-  min-height: 2.35rem;
-  padding: 0;
-}
-
-.tags-manager {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-  max-width: 860px;
-}
-
-.tags-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.tags-header h2 {
-  margin: 0;
-}
-
-.tags-refresh {
-  width: auto;
-}
-
-.tags-hint {
-  margin: 0;
-  color: var(--bo-ink-muted);
-}
-
-.tags-empty {
-  margin: 0;
-  color: var(--bo-ink-muted);
-}
-
-.tags-list {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.tags-item {
-  background: var(--bo-surface-panel);
-  border: 1px solid var(--bo-border-soft);
-  border-radius: 12px;
-  padding: 0.85rem;
-}
-
-.tags-item-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.tags-item-header h3 {
-  margin: 0;
-}
-
-.tags-item-meta {
-  display: grid;
-  gap: 0.3rem;
-}
 
 .tags-dialog-preview {
   display: flex;
@@ -1286,24 +1047,6 @@ select:focus {
   gap: 0.45rem;
 }
 
-.users-header h2 {
-  margin: 0;
-}
-
-.users-header p {
-  margin: 0.2rem 0 0;
-  color: var(--bo-ink-muted);
-}
-
-.users-header {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.users-header > .btn {
-  justify-self: start;
-}
-
 .users-create {
   display: grid;
   gap: 0.5rem;
@@ -1320,38 +1063,6 @@ select:focus {
 .users-create label {
   display: grid;
   gap: 0.2rem;
-}
-
-.users-list {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.users-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  background: var(--bo-surface-panel);
-  border: 1px solid var(--bo-border-soft);
-  border-radius: 12px;
-  padding: 0.7rem;
-}
-
-.users-item-meta {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.users-badges {
-  display: inline-flex;
-  gap: 0.35rem;
-}
-
-.users-item-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
 }
 
 .machine-access-view {

--- a/BoardOil.Web/src/styles/entity-rows.css
+++ b/BoardOil.Web/src/styles/entity-rows.css
@@ -1,0 +1,85 @@
+.entity-rows-page {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.9rem;
+  max-width: 860px;
+}
+
+.entity-rows-page--compact {
+  max-width: 760px;
+}
+
+.entity-rows-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.entity-rows-header h2 {
+  margin: 0;
+}
+
+.entity-rows-header-copy {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.entity-rows-header-copy p {
+  margin: 0;
+  color: var(--bo-ink-muted);
+}
+
+.entity-rows-empty {
+  margin: 0;
+  color: var(--bo-ink-muted);
+}
+
+.entity-rows-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.entity-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  background: var(--bo-surface-panel);
+  border: 1px solid var(--bo-border-soft);
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.entity-row-main {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.entity-row-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.entity-row-badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.entity-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.entity-row-action-icon {
+  min-width: 2.35rem;
+  min-height: 2.35rem;
+  padding: 0;
+}

--- a/BoardOil.Web/src/views/BoardsView.vue
+++ b/BoardOil.Web/src/views/BoardsView.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="boards-view">
-    <header class="boards-header">
+  <section class="entity-rows-page">
+    <header class="entity-rows-header">
       <h2>Boards</h2>
       <button
         v-if="isAdmin"
@@ -13,19 +13,23 @@
       </button>
     </header>
 
-    <p v-if="boards.length === 0" class="boards-empty">No boards yet.</p>
+    <p v-if="boards.length === 0" class="entity-rows-empty">No boards yet.</p>
 
-    <ul v-else class="boards-list">
-      <li v-for="board in boards" :key="`${board.id}-${board.name}`" class="boards-item">
-        <div class="boards-row">
-          <button type="button" class="btn boards-open" @click="openBoard(board.id)">
-            <span class="card-id boards-meta">#{{ board.id }}</span>
-            <span class="boards-name">{{ board.name }}</span>
-          </button>
-          <div v-if="isAdmin" class="boards-actions">
+    <ul v-else class="entity-rows-list">
+      <li v-for="board in boards" :key="`${board.id}-${board.name}`">
+        <div class="entity-row">
+          <div class="entity-row-main">
+            <span class="card-id">#{{ board.id }}</span>
+            <span class="entity-row-title">{{ board.name }}</span>
+          </div>
+          <div class="entity-row-actions">
+            <button type="button" class="btn btn--secondary" :disabled="busy" @click="openBoard(board.id)">
+              Open
+            </button>
             <button
+              v-if="isAdmin"
               type="button"
-              class="btn btn--secondary boards-action boards-action-icon"
+              class="btn btn--secondary entity-row-action-icon"
               :disabled="busy"
               aria-label="Rename board"
               title="Rename board"
@@ -34,8 +38,9 @@
               <Pencil :size="16" aria-hidden="true" />
             </button>
             <button
+              v-if="isAdmin"
               type="button"
-              class="btn btn--danger boards-action boards-action-icon"
+              class="btn btn--danger entity-row-action-icon"
               :disabled="busy"
               aria-label="Delete board"
               title="Delete board"

--- a/BoardOil.Web/src/views/ColumnsManagerView.vue
+++ b/BoardOil.Web/src/views/ColumnsManagerView.vue
@@ -1,14 +1,14 @@
 <template>
   <template v-if="board">
-    <section class="toolbar columns-manager-toolbar">
+    <section class="toolbar entity-rows-header columns-manager-toolbar">
       <button type="button" class="btn" aria-label="Add column" title="Add column" @click="openNewColumnDraft">
         <Plus :size="16" aria-hidden="true" />
         <span>Add Column</span>
       </button>
     </section>
 
-    <section class="column-manager">
-      <article v-if="newColumnDraftTitle !== null" class="column-manager-item create-column-inline">
+    <section class="entity-rows-list columns-manager-list">
+      <article v-if="newColumnDraftTitle !== null" class="entity-row columns-manager-item create-column-inline">
         <label class="create-card-inline-label">
           Column title
           <input
@@ -21,7 +21,7 @@
             @keydown.esc.prevent="closeNewColumnDraft"
           />
         </label>
-        <div class="column-create-actions">
+        <div class="entity-row-actions column-create-actions">
           <button type="button" class="btn" aria-label="Save new column" title="Save new column" @click="saveNewColumnDraft">
             Save
           </button>
@@ -34,15 +34,16 @@
       <article
         v-for="column in board.columns"
         :key="column.id"
-        class="column-manager-item draggable-column"
+        class="entity-row columns-manager-item draggable-column"
         :class="{ 'drag-over': dragOverColumnId === column.id }"
         @dragover="onColumnDragOver(column.id, $event)"
         @dragleave="onColumnDragLeave(column.id)"
         @drop="onColumnDrop(column.id, $event)"
       >
-        <div class="column-manager-header">
-          <h3 class="column-manager-title">{{ column.title }}</h3>
-          <div class="column-manager-actions">
+        <div class="entity-row-main">
+          <h3 class="entity-row-title">{{ column.title }}</h3>
+        </div>
+        <div class="entity-row-actions">
             <button type="button" class="btn btn--secondary" @click="openColumnEditor(column.id)">
               Edit
             </button>
@@ -57,7 +58,6 @@
             >
               <GripVertical :size="16" aria-hidden="true" />
             </div>
-          </div>
         </div>
       </article>
     </section>
@@ -210,3 +210,63 @@ watch(
   { immediate: true }
 );
 </script>
+
+<style scoped>
+.columns-manager-toolbar {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.columns-manager-list {
+  margin-top: 0;
+  max-width: 56rem;
+}
+
+.columns-manager-item {
+  gap: 0.5rem;
+}
+
+.create-column-inline {
+  border-style: dashed;
+}
+
+.column-create-actions {
+  justify-content: flex-end;
+}
+
+.columns-manager-item label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--bo-ink-default);
+}
+
+.column-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  padding: 0.35rem 0.45rem;
+  border: 1px solid var(--bo-border-default);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--bo-link);
+  cursor: grab;
+  user-select: none;
+}
+
+.column-drag-handle:hover {
+  background: var(--bo-surface-energy);
+  border-color: var(--bo-colour-energy);
+  color: var(--bo-colour-energy);
+}
+
+.column-drag-handle:active {
+  cursor: grabbing;
+}
+
+.draggable-column.drag-over {
+  border-color: var(--bo-colour-secondary);
+  box-shadow: 0 0 0 2px rgba(105, 193, 206, 0.28);
+}
+</style>

--- a/BoardOil.Web/src/views/TagsManagerView.vue
+++ b/BoardOil.Web/src/views/TagsManagerView.vue
@@ -1,24 +1,20 @@
 <template>
-  <section class="tags-manager">
-    <header class="tags-header">
+  <section class="entity-rows-page">
+    <header class="entity-rows-header">
       <h2>Tags</h2>
     </header>
 
-    <p v-if="tagNames.length === 0" class="tags-empty">No tags yet. Add one from any card editor.</p>
+    <p v-if="tagNames.length === 0" class="entity-rows-empty">No tags yet. Add one from any card editor.</p>
 
-    <section v-else class="tags-list">
-      <article v-for="tagName in tagNames" :key="tagName" class="tags-item">
-        <div class="tags-item-header">
-          <div class="tags-item-meta">
-            <h3>{{ tagName }}</h3>
+    <section v-else class="entity-rows-list">
+      <article v-for="tagName in tagNames" :key="tagName" class="entity-row">
+        <div class="entity-row-main">
+          <h3 class="entity-row-title">{{ tagName }}</h3>
             <span class="tag-pill" :style="tagStyle(tagName)">
               {{ tagName }}
             </span>
-          </div>
-          <button type="button" class="btn btn--secondary tags-edit" :disabled="busy" @click="openEditor(tagName)">
-            Edit
-          </button>
         </div>
+        <button type="button" class="btn btn--secondary" :disabled="busy" @click="openEditor(tagName)">Edit</button>
       </article>
     </section>
   </section>

--- a/BoardOil.Web/src/views/UsersManagerView.vue
+++ b/BoardOil.Web/src/views/UsersManagerView.vue
@@ -1,7 +1,7 @@
 <template>
-  <section class="users-manager">
-    <header class="users-header">
-      <div>
+  <section class="entity-rows-page entity-rows-page--compact">
+    <header class="entity-rows-header users-header">
+      <div class="entity-rows-header-copy">
         <h2>User Management</h2>
         <p>Create and manage local BoardOil accounts.</p>
       </div>
@@ -11,16 +11,16 @@
     <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
     <p v-if="successMessage" class="success">{{ successMessage }}</p>
 
-    <section class="users-list">
-      <article v-for="user in users" :key="user.id" class="users-item">
-        <div class="users-item-meta">
-          <strong>{{ user.userName }}</strong>
-          <span class="users-badges">
+    <section class="entity-rows-list">
+      <article v-for="user in users" :key="user.id" class="entity-row">
+        <div class="entity-row-main">
+          <strong class="entity-row-title">{{ user.userName }}</strong>
+          <span class="entity-row-badges">
             <span class="card-id">{{ user.role }}</span>
             <span class="card-id">{{ user.isActive ? 'Active' : 'Inactive' }}</span>
           </span>
         </div>
-        <div class="users-item-actions">
+        <div class="entity-row-actions">
           <select :value="user.role" :disabled="busy" @change="onRoleChange(user.id, ($event.target as HTMLSelectElement).value)">
             <option value="Standard">Standard</option>
             <option value="Admin">Admin</option>
@@ -136,3 +136,9 @@ onMounted(async () => {
   await loadUsers();
 });
 </script>
+
+<style scoped>
+.users-header {
+  align-items: flex-end;
+}
+</style>


### PR DESCRIPTION
### Motivation
- Reduce duplication and standardise list/row layouts for management pages by introducing a shared entity-row pattern and moving repeated styles out of page-specific CSS into a single stylesheet.

### Description
- Add `BoardOil.Web/src/styles/entity-rows.css` with shared classes like `.entity-rows-page`, `.entity-rows-list`, `.entity-row`, `.entity-row-main`, `.entity-row-actions`, `.entity-row-title`, `.entity-row-badges`, and `.entity-row-action-icon`.
- Import the new stylesheet from `BoardOil.Web/src/style.css` and remove duplicated page-specific row styles from the global stylesheet.
- Migrate `BoardsView.vue`, `TagsManagerView.vue`, and `UsersManagerView.vue` to use the new entity-row classes and update markup/action buttons accordingly.
- Refactor `ColumnsManagerView.vue` to adopt the entity-row structure and move the remaining column-specific styles into a scoped `<style>` block in the same file.

### Testing
- No automated tests were run as part of this change. Please run the repository's existing build/tests (`npm run build`, `npm test`, `npm run lint`) in CI to verify integration with the rest of the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caefa1d6f08321afb6caddbdb2e109)