### PR TITLE
Comment support across UI, MCP, realtime, import/export, and archive

### DIFF
--- a/BoardOil.Abstractions/Abstractions/IBoardEvents.cs
+++ b/BoardOil.Abstractions/Abstractions/IBoardEvents.cs
@@ -13,6 +13,7 @@ public interface IBoardEvents
     Task CardUpdatedAsync(int boardId, CardDto card);
     Task CardDeletedAsync(int boardId, int cardId);
     Task CardMovedAsync(int boardId, CardDto card);
+    Task CommentCreatedAsync(int boardId, CardCommentDto comment);
 
     Task ResyncRequestedAsync(int boardId);
 }

--- a/BoardOil.Abstractions/Card/ICardCommentService.cs
+++ b/BoardOil.Abstractions/Card/ICardCommentService.cs
@@ -1,0 +1,10 @@
+using BoardOil.Contracts.Card;
+using BoardOil.Contracts.Contracts;
+
+namespace BoardOil.Abstractions.Card;
+
+public interface ICardCommentService
+{
+    Task<ApiResult<IReadOnlyList<CardCommentDto>>> GetCommentsAsync(int boardId, int cardId, int actorUserId);
+    Task<ApiResult<CardCommentDto>> CreateCommentAsync(int boardId, int cardId, CreateCardCommentRequest request, int actorUserId);
+}

--- a/BoardOil.Api.Tests/AuthAuthorisationIntegrationTests.cs
+++ b/BoardOil.Api.Tests/AuthAuthorisationIntegrationTests.cs
@@ -155,5 +155,26 @@ public sealed class AuthAuthorisationBoardAccessIntegrationTests : AuthAuthorisa
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
+    [Fact]
+    public async Task StandardUser_WithoutBoardMembership_CreateComment_ShouldReturnForbidden()
+    {
+        // Arrange
+        var adminClient = Factory.CreateClient();
+        var standardClient = Factory.CreateClient();
+        await RegisterInitialAdminAsync(adminClient);
+        await CreateUserAsAdminAsync(adminClient, "member", "Password1234!", "Standard");
+        var columnId = await SeedBoardColumnAsync("Todo");
+        var cardId = await SeedBoardCardAsync(columnId, "Task A", "Desc");
+        await LoginAsAsync(standardClient, "member", "Password1234!");
+
+        // Act
+        var response = await standardClient.PostAsJsonAsync(
+            $"/api/boards/1/cards/{cardId}/comments",
+            new CreateCardCommentRequest("No access"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
     private sealed record BoardTagDto(int Id, string Name);
 }

--- a/BoardOil.Api.Tests/BoardApiCardIntegrationTests.cs
+++ b/BoardOil.Api.Tests/BoardApiCardIntegrationTests.cs
@@ -186,4 +186,34 @@ public sealed class BoardApiCardIntegrationTests
         Assert.Null(payload.Message);
     }
 
+    [Fact]
+    public async Task CardCommentsEndpoints_ShouldCreateAndListComments()
+    {
+        // Arrange
+        var columnId = await SeedBoardColumnAsync("Todo");
+        var cardId = await SeedBoardCardAsync(columnId, "Task A", "Desc");
+
+        // Act
+        var createResponse = await Client.PostAsJsonAsync(
+            $"/api/boards/1/cards/{cardId}/comments",
+            new CreateCardCommentRequest("First comment"));
+        var createdEnvelope = await createResponse.Content.ReadFromJsonAsync<ApiEnvelope<CardCommentDto>>(JsonOptions);
+        var listResponse = await Client.GetAsync($"/api/boards/1/cards/{cardId}/comments");
+        var listEnvelope = await listResponse.Content.ReadFromJsonAsync<ApiEnvelope<IReadOnlyList<CardCommentDto>>>(JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        Assert.NotNull(createdEnvelope);
+        Assert.True(createdEnvelope!.Success);
+        Assert.NotNull(createdEnvelope.Data);
+        Assert.Equal("First comment", createdEnvelope.Data!.Text);
+
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.NotNull(listEnvelope);
+        Assert.True(listEnvelope!.Success);
+        Assert.NotNull(listEnvelope.Data);
+        Assert.Single(listEnvelope.Data);
+        Assert.Equal("First comment", listEnvelope.Data[0].Text);
+    }
+
 }

--- a/BoardOil.Api.Tests/MachinePatIntegrationTests.cs
+++ b/BoardOil.Api.Tests/MachinePatIntegrationTests.cs
@@ -49,6 +49,7 @@ public sealed class MachinePatIntegrationTests : ApiFactoryIntegrationTestBase
         Assert.Contains("board_get", toolNames);
         Assert.Contains("card_get", toolNames);
         Assert.Contains("card_create", toolNames);
+        Assert.Contains("card_comment_create", toolNames);
     }
 
     [Fact]
@@ -242,6 +243,44 @@ public sealed class MachinePatIntegrationTests : ApiFactoryIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, createCardResponse.StatusCode);
+        AssertMcpForbidden(payload);
+    }
+
+    [Fact]
+    public async Task PatWithReadOnlyScope_CardCommentCreate_ShouldReturnForbiddenToolError()
+    {
+        // Arrange
+        var adminClient = CreateClient();
+        await RegisterInitialAdminAsync(adminClient);
+
+        var createResponse = await adminClient.PostAsJsonAsync(
+            "/api/auth/access-tokens",
+            new CreateMachinePatRequest("read-only-comment-token", 30, ["mcp:read"]));
+        createResponse.EnsureSuccessStatusCode();
+        var created = await createResponse.Content.ReadFromJsonAsync<ApiEnvelope<CreatedMachinePatEnvelope>>();
+        Assert.NotNull(created);
+        Assert.NotNull(created!.Data);
+
+        // Act
+        var createCommentResponse = await SendMcpRequestAsync(
+            adminClient,
+            created.Data!.PlainTextToken,
+            "tools/call",
+            new
+            {
+                name = "card_comment_create",
+                arguments = new
+                {
+                    boardId = 1,
+                    id = 1,
+                    text = "Blocked by scope"
+                }
+            },
+            "card-comment-create-forbidden");
+        using var payload = await ParseMcpJsonAsync(createCommentResponse);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, createCommentResponse.StatusCode);
         AssertMcpForbidden(payload);
     }
 

--- a/BoardOil.Api.Tests/McpToolDiscoveryIntegrationTests.cs
+++ b/BoardOil.Api.Tests/McpToolDiscoveryIntegrationTests.cs
@@ -179,6 +179,12 @@ public sealed class McpToolDiscoveryIntegrationTests : McpIntegrationTestBase
         Assert.DoesNotContain("columnId", cardUpdateRequired);
         Assert.Contains("cardTypeId", cardUpdateRequired);
         Assert.DoesNotContain("assignedUserId", cardUpdateRequired);
+
+        var cardCommentCreateTool = McpJsonRpcClient.GetToolByName(toolsListPayload, ToolNames.CardCommentCreate);
+        var cardCommentCreateProperties = cardCommentCreateTool.GetProperty("inputSchema").GetProperty("properties");
+        Assert.True(cardCommentCreateProperties.TryGetProperty("boardId", out _));
+        Assert.True(cardCommentCreateProperties.TryGetProperty("id", out _));
+        Assert.True(cardCommentCreateProperties.TryGetProperty("text", out _));
     }
 
     private sealed record UpdateConfigurationRequest(string? McpPublicBaseUrl);

--- a/BoardOil.Api.Tests/McpToolExecutionIntegrationTests.cs
+++ b/BoardOil.Api.Tests/McpToolExecutionIntegrationTests.cs
@@ -83,6 +83,7 @@ public sealed class McpToolExecutionIntegrationTests : McpIntegrationTestBase
         Assert.Contains("board_get", toolNames);
         Assert.Contains("card_get", toolNames);
         Assert.Contains("card_create", toolNames);
+        Assert.Contains("card_comment_create", toolNames);
         Assert.DoesNotContain("card.move_by_column_name", toolNames);
 
         var cards = McpJsonRpcClient.GetStructuredContent(verifyPayload)
@@ -252,6 +253,116 @@ public sealed class McpToolExecutionIntegrationTests : McpIntegrationTestBase
 
         var cardData = McpJsonRpcClient.GetStructuredContent(cardGetPayload);
         Assert.Equal(fullDescription, cardData.GetProperty("description").GetString());
+        Assert.True(cardData.TryGetProperty("comments", out var comments));
+        Assert.Empty(comments.EnumerateArray());
+    }
+
+    [Fact]
+    public async Task CardCommentCreate_ThenCardGet_ShouldIncludeCommentInReverseChronologicalOrder()
+    {
+        var client = CreateClient();
+        await RegisterInitialAdminAsync(client);
+        var patToken = await CreateMachinePatAsync(client);
+
+        var boardGetResponse = await McpJsonRpcClient.SendRequestAsync(
+            client,
+            "tools/call",
+            new
+            {
+                name = "board.get",
+                arguments = new { id = 1 }
+            },
+            "board-get-before-comment-create",
+            patToken);
+        Assert.Equal(HttpStatusCode.OK, boardGetResponse.StatusCode);
+        using var boardGetPayload = await McpJsonRpcClient.ParseJsonAsync(boardGetResponse);
+
+        var todoColumnId = McpJsonRpcClient.GetStructuredContent(boardGetPayload)
+            .GetProperty("columns")
+            .EnumerateArray()
+            .Single(column => column.GetProperty("title").GetString() == "Todo")
+            .GetProperty("id")
+            .GetInt32();
+
+        var createCardResponse = await McpJsonRpcClient.SendRequestAsync(
+            client,
+            "tools/call",
+            new
+            {
+                name = "card.create",
+                arguments = new
+                {
+                    boardId = 1,
+                    columnId = todoColumnId,
+                    title = "Comment target card",
+                    description = "",
+                    tagNames = Array.Empty<string>()
+                }
+            },
+            "card-create-comment-target",
+            patToken);
+        Assert.Equal(HttpStatusCode.OK, createCardResponse.StatusCode);
+        using var createCardPayload = await McpJsonRpcClient.ParseJsonAsync(createCardResponse);
+        var cardId = McpJsonRpcClient.GetStructuredContent(createCardPayload).GetProperty("card").GetProperty("id").GetInt32();
+
+        var addFirstCommentResponse = await McpJsonRpcClient.SendRequestAsync(
+            client,
+            "tools/call",
+            new
+            {
+                name = "card_comment_create",
+                arguments = new
+                {
+                    boardId = 1,
+                    id = cardId,
+                    text = "First MCP comment"
+                }
+            },
+            "card-comment-create-first",
+            patToken);
+        Assert.Equal(HttpStatusCode.OK, addFirstCommentResponse.StatusCode);
+        using var addFirstCommentPayload = await McpJsonRpcClient.ParseJsonAsync(addFirstCommentResponse);
+        Assert.False(addFirstCommentPayload.RootElement.GetProperty("result").GetProperty("isError").GetBoolean());
+
+        var addSecondCommentResponse = await McpJsonRpcClient.SendRequestAsync(
+            client,
+            "tools/call",
+            new
+            {
+                name = "card_comment_create",
+                arguments = new
+                {
+                    boardId = 1,
+                    id = cardId,
+                    text = "Second MCP comment"
+                }
+            },
+            "card-comment-create-second",
+            patToken);
+        Assert.Equal(HttpStatusCode.OK, addSecondCommentResponse.StatusCode);
+        using var addSecondCommentPayload = await McpJsonRpcClient.ParseJsonAsync(addSecondCommentResponse);
+        Assert.False(addSecondCommentPayload.RootElement.GetProperty("result").GetProperty("isError").GetBoolean());
+
+        var cardGetResponse = await McpJsonRpcClient.SendRequestAsync(
+            client,
+            "tools/call",
+            new
+            {
+                name = "card.get",
+                arguments = new { boardId = 1, id = cardId }
+            },
+            "card-get-after-comment-create",
+            patToken);
+        Assert.Equal(HttpStatusCode.OK, cardGetResponse.StatusCode);
+        using var cardGetPayload = await McpJsonRpcClient.ParseJsonAsync(cardGetResponse);
+
+        var comments = McpJsonRpcClient.GetStructuredContent(cardGetPayload)
+            .GetProperty("comments")
+            .EnumerateArray()
+            .ToArray();
+        Assert.Equal(2, comments.Length);
+        Assert.Equal("Second MCP comment", comments[0].GetProperty("text").GetString());
+        Assert.Equal("First MCP comment", comments[1].GetProperty("text").GetString());
     }
 
     [Fact]

--- a/BoardOil.Api.Tests/RealtimeIntegrationTests.cs
+++ b/BoardOil.Api.Tests/RealtimeIntegrationTests.cs
@@ -118,6 +118,39 @@ public sealed class RealtimeIntegrationTests : BoardApiIntegrationTestBase
         await WaitAsync(resyncEvent.Task);
     }
 
+    [Fact]
+    public async Task CommentCreated_ShouldBroadcastToSubscribedClients()
+    {
+        // Arrange
+        var columnId = await SeedBoardColumnAsync("Todo");
+        var cardId = await SeedBoardCardAsync(columnId, "Realtime Task", "Desc");
+
+        await using var connectionA = CreateHubConnection();
+        await using var connectionB = CreateHubConnection();
+
+        var eventA = new TaskCompletionSource<CardCommentDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventB = new TaskCompletionSource<CardCommentDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connectionA.On<CardCommentDto>("CommentCreated", comment => eventA.TrySetResult(comment));
+        connectionB.On<CardCommentDto>("CommentCreated", comment => eventB.TrySetResult(comment));
+
+        await StartConnectionsAsync(1, connectionA, connectionB);
+
+        // Act
+        var createCommentResponse = await Client.PostAsJsonAsync(
+            $"/api/boards/1/cards/{cardId}/comments",
+            new CreateCardCommentRequest("Realtime comment"));
+        createCommentResponse.EnsureSuccessStatusCode();
+
+        // Assert
+        var commentA = await WaitAsync(eventA.Task);
+        var commentB = await WaitAsync(eventB.Task);
+
+        Assert.Equal(cardId, commentA.CardId);
+        Assert.Equal("Realtime comment", commentA.Text);
+        Assert.Equal(commentA.Id, commentB.Id);
+    }
+
     private static async Task StartConnectionsAsync(int boardId, params HubConnection[] connections)
     {
         foreach (var connection in connections)

--- a/BoardOil.Api/Endpoints/CardEndpoints.cs
+++ b/BoardOil.Api/Endpoints/CardEndpoints.cs
@@ -31,6 +31,12 @@ public static class CardEndpoints
         cardEndpoints.MapPut("/{id:int}", async (int boardId, int id, UpdateCardRequest request, ICardService cardService, HttpContext httpContext) =>
             (await cardService.UpdateCardAsync(boardId, id, request, httpContext.GetActorUserId())).ToHttpResult());
 
+        cardEndpoints.MapGet("/{id:int}/comments", async (int boardId, int id, ICardCommentService cardCommentService, HttpContext httpContext) =>
+            (await cardCommentService.GetCommentsAsync(boardId, id, httpContext.GetActorUserId())).ToHttpResult());
+
+        cardEndpoints.MapPost("/{id:int}/comments", async (int boardId, int id, CreateCardCommentRequest request, ICardCommentService cardCommentService, HttpContext httpContext) =>
+            (await cardCommentService.CreateCommentAsync(boardId, id, request, httpContext.GetActorUserId())).ToHttpResult());
+
         cardEndpoints.MapPatch("/{id:int}/move", async (int boardId, int id, MoveCardRequest request, ICardService cardService, HttpContext httpContext) =>
             (await cardService.MoveCardAsync(boardId, id, request, httpContext.GetActorUserId())).ToHttpResult());
 

--- a/BoardOil.Api/Endpoints/InternalRealtimeEndpoints.cs
+++ b/BoardOil.Api/Endpoints/InternalRealtimeEndpoints.cs
@@ -138,6 +138,9 @@ public static class InternalRealtimeEndpoints
             BoardRealtimeEventTypes.CardMoved => request.Card is null
                 ? ApiErrors.BadRequest("Card payload is required for card_moved.")
                 : null,
+            BoardRealtimeEventTypes.CommentCreated => request.Comment is null
+                ? ApiErrors.BadRequest("Comment payload is required for comment_created.")
+                : null,
             _ => ApiErrors.BadRequest("Unsupported realtime event type.")
         };
     }
@@ -152,6 +155,7 @@ public static class InternalRealtimeEndpoints
             BoardRealtimeEventTypes.CardUpdated => boardEvents.CardUpdatedAsync(request.BoardId, request.Card!),
             BoardRealtimeEventTypes.CardDeleted => boardEvents.CardDeletedAsync(request.BoardId, request.CardId!.Value),
             BoardRealtimeEventTypes.CardMoved => boardEvents.CardMovedAsync(request.BoardId, request.Card!),
+            BoardRealtimeEventTypes.CommentCreated => boardEvents.CommentCreatedAsync(request.BoardId, request.Comment!),
             _ => Task.CompletedTask
         };
 }

--- a/BoardOil.Api/Mcp/McpMappingExtensions.cs
+++ b/BoardOil.Api/Mcp/McpMappingExtensions.cs
@@ -44,7 +44,18 @@ public static class McpMappingExtensions
             card.TagNames,
             card.UpdatedAtUtc,
             card.AssignedUserId,
-            card.AssignedUserName);
+            card.AssignedUserName,
+            []);
+
+    public static McpCardCommentSnapshot ToMcp(this CardCommentDto comment) =>
+        new(
+            comment.Id,
+            comment.CardId,
+            comment.AuthorUserId,
+            comment.Text,
+            comment.CreatedAtUtc,
+            comment.AuthorDisplayName,
+            comment.AuthorImageRelativePath);
 
     private static McpBoardCardSnapshot ToMcpBoardSnapshot(this CardDto card) =>
         new(

--- a/BoardOil.Api/Mcp/McpServiceCollectionExtensions.cs
+++ b/BoardOil.Api/Mcp/McpServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class McpServiceCollectionExtensions
         RegisterTool<CardUpdateTool>(services);
         RegisterTool<CardMoveTool>(services);
         RegisterTool<CardDeleteTool>(services);
+        RegisterTool<CardCommentCreateTool>(services);
 
         services.AddSingleton<McpToolRegistry>();
         services.AddSingleton<McpToolDispatcher>();

--- a/BoardOil.Api/Mcp/Tools/CardCommentCreateTool.cs
+++ b/BoardOil.Api/Mcp/Tools/CardCommentCreateTool.cs
@@ -1,25 +1,24 @@
 using BoardOil.Abstractions.Card;
 using BoardOil.Contracts.Auth;
+using BoardOil.Contracts.Card;
 using BoardOil.Contracts.Contracts;
 using BoardOil.Mcp.Contracts;
 using BoardOil.Mcp.Contracts.Schemas;
 
 namespace BoardOil.Api.Mcp;
 
-public sealed class CardGetTool(
-    ICardService cardService,
+public sealed class CardCommentCreateTool(
     ICardCommentService cardCommentService,
-    IMcpAuthorisationService authorisationService) : McpToolBase<CardGetInput, McpCardSnapshot>(authorisationService)
+    IMcpAuthorisationService authorisationService) : McpToolBase<CardCommentCreateInput, CardCommentMutationOutput>(authorisationService)
 {
-    private readonly ICardService _cardService = cardService;
     private readonly ICardCommentService _cardCommentService = cardCommentService;
 
     public override McpToolDefinition Definition { get; } =
-        new(ToolNames.CardGet, "Get a card snapshot including description, tags, and comments.", ToolSchemas.CardGetInput, ToolSchemas.ObjectOutput);
+        new(ToolNames.CardCommentCreate, "Add a comment to a card.", ToolSchemas.CardCommentCreateInput, ToolSchemas.ObjectOutput);
 
-    protected override async Task<McpToolResult<McpCardSnapshot>> ExecuteCoreAsync(
+    protected override async Task<McpToolResult<CardCommentMutationOutput>> ExecuteCoreAsync(
         McpInvocationContext context,
-        CardGetInput input,
+        CardCommentCreateInput input,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -37,29 +36,22 @@ public sealed class CardGetTool(
         var boardId = input.BoardId!.Value;
         var cardId = input.Id!.Value;
 
-        var accessError = AuthorisationService.EnsurePatToolAccess(context.PatAccessContext, MachinePatScopes.McpRead, boardId);
+        var accessError = AuthorisationService.EnsurePatToolAccess(context.PatAccessContext, MachinePatScopes.McpWrite, boardId);
         if (accessError is not null)
         {
             return Failure(accessError);
         }
 
-        var result = await _cardService.GetCardAsync(boardId, cardId, context.ActorUserId);
+        var result = await _cardCommentService.CreateCommentAsync(
+            boardId,
+            cardId,
+            new CreateCardCommentRequest(input.Text),
+            context.ActorUserId);
         if (!result.Success || result.Data is null)
         {
             return Failure(result.ToMcpError());
         }
 
-        var commentsResult = await _cardCommentService.GetCommentsAsync(boardId, cardId, context.ActorUserId);
-        if (!commentsResult.Success || commentsResult.Data is null)
-        {
-            return Failure(commentsResult.ToMcpError());
-        }
-
-        var cardSnapshot = result.Data.ToMcp() with
-        {
-            Comments = commentsResult.Data.Select(comment => comment.ToMcp()).ToArray()
-        };
-
-        return Success(cardSnapshot);
+        return Success(new CardCommentMutationOutput(result.Data.ToMcp(), "created"));
     }
 }

--- a/BoardOil.Api/Realtime/BoardRealtimeNotifier.cs
+++ b/BoardOil.Api/Realtime/BoardRealtimeNotifier.cs
@@ -30,6 +30,9 @@ public sealed class BoardRealtimeNotifier(
     public Task CardMovedAsync(int boardId, CardDto card) =>
         TryPublishAsync(() => hubContext.Clients.Group(BoardHubGroupName.For(boardId)).SendAsync("CardMoved", card), nameof(CardMovedAsync));
 
+    public Task CommentCreatedAsync(int boardId, CardCommentDto comment) =>
+        TryPublishAsync(() => hubContext.Clients.Group(BoardHubGroupName.For(boardId)).SendAsync("CommentCreated", comment), nameof(CommentCreatedAsync));
+
     public Task ResyncRequestedAsync(int boardId) =>
         TryPublishAsync(() => hubContext.Clients.Group(BoardHubGroupName.For(boardId)).SendAsync("ResyncRequested"), nameof(ResyncRequestedAsync));
 

--- a/BoardOil.Contracts/Board/BoardPackageContracts.cs
+++ b/BoardOil.Contracts/Board/BoardPackageContracts.cs
@@ -39,7 +39,13 @@ public sealed record BoardPackageCardDto(
     string Description,
     string CardTypeName,
     IReadOnlyList<string> TagNames,
-    string? AssignedUserEmail = null);
+    string? AssignedUserEmail = null,
+    IReadOnlyList<BoardPackageCommentDto>? Comments = null);
+
+public sealed record BoardPackageCommentDto(
+    string Text,
+    DateTime CreatedAtUtc,
+    string? AuthorEmail = null);
 
 public sealed record BoardPackageArchiveDto(
     IReadOnlyList<BoardPackageArchivedCardDto> Cards);

--- a/BoardOil.Contracts/Card/CardContracts.cs
+++ b/BoardOil.Contracts/Card/CardContracts.cs
@@ -12,7 +12,9 @@ public sealed record CardCommentDto(
     int CardId,
     int AuthorUserId,
     string Text,
-    DateTime CreatedAtUtc);
+    DateTime CreatedAtUtc,
+    string? AuthorDisplayName = null,
+    string? AuthorImageRelativePath = null);
 
 public sealed record CardDto(
     int Id,

--- a/BoardOil.Contracts/Card/CardContracts.cs
+++ b/BoardOil.Contracts/Card/CardContracts.cs
@@ -10,7 +10,7 @@ public sealed record CardTagDto(
 public sealed record CardCommentDto(
     int Id,
     int CardId,
-    int AuthorUserId,
+    int? AuthorUserId,
     string Text,
     DateTime CreatedAtUtc,
     string? AuthorDisplayName = null,

--- a/BoardOil.Contracts/Card/CardContracts.cs
+++ b/BoardOil.Contracts/Card/CardContracts.cs
@@ -7,6 +7,13 @@ public sealed record CardTagDto(
     string StylePropertiesJson,
     string? Emoji);
 
+public sealed record CardCommentDto(
+    int Id,
+    int CardId,
+    int AuthorUserId,
+    string Text,
+    DateTime CreatedAtUtc);
+
 public sealed record CardDto(
     int Id,
     int BoardColumnId,
@@ -83,3 +90,6 @@ public sealed record UpdateCardRequest(
 public sealed record MoveCardRequest(
     int BoardColumnId,
     int? PositionAfterCardId);
+
+public sealed record CreateCardCommentRequest(
+    string Text);

--- a/BoardOil.Contracts/Realtime/BoardRealtimeRelayContracts.cs
+++ b/BoardOil.Contracts/Realtime/BoardRealtimeRelayContracts.cs
@@ -18,6 +18,7 @@ public static class BoardRealtimeEventTypes
     public const string CardUpdated = "card_updated";
     public const string CardDeleted = "card_deleted";
     public const string CardMoved = "card_moved";
+    public const string CommentCreated = "comment_created";
 }
 
 public sealed record BoardRealtimeRelayEvent(
@@ -26,4 +27,5 @@ public sealed record BoardRealtimeRelayEvent(
     ColumnDto? Column = null,
     int? ColumnId = null,
     CardDto? Card = null,
-    int? CardId = null);
+    int? CardId = null,
+    CardCommentDto? Comment = null);

--- a/BoardOil.Ef/BoardOilDbContext.cs
+++ b/BoardOil.Ef/BoardOilDbContext.cs
@@ -12,6 +12,7 @@ public sealed class BoardOilDbContext(DbContextOptions<BoardOilDbContext> option
     public DbSet<EntityCardType> CardTypes => Set<EntityCardType>();
     public DbSet<EntityTag> Tags => Set<EntityTag>();
     public DbSet<EntityCardTag> CardTags => Set<EntityCardTag>();
+    public DbSet<EntityCardComment> CardComments => Set<EntityCardComment>();
     public DbSet<EntityBoardMember> BoardMembers => Set<EntityBoardMember>();
     public DbSet<EntityUser> Users => Set<EntityUser>();
     public DbSet<EntityRefreshToken> RefreshTokens => Set<EntityRefreshToken>();
@@ -78,6 +79,10 @@ public sealed class BoardOilDbContext(DbContextOptions<BoardOilDbContext> option
             .HasForeignKey(x => x.AssignedUserId)
             .OnDelete(DeleteBehavior.SetNull);
         card.HasMany(x => x.CardTags)
+            .WithOne(x => x.Card)
+            .HasForeignKey(x => x.CardId)
+            .OnDelete(DeleteBehavior.Cascade);
+        card.HasMany(x => x.Comments)
             .WithOne(x => x.Card)
             .HasForeignKey(x => x.CardId)
             .OnDelete(DeleteBehavior.Cascade);
@@ -157,6 +162,20 @@ public sealed class BoardOilDbContext(DbContextOptions<BoardOilDbContext> option
             .WithOne(x => x.User)
             .HasForeignKey(x => x.UserId)
             .OnDelete(DeleteBehavior.Cascade);
+        user.HasMany(x => x.CardComments)
+            .WithOne(x => x.AuthorUser)
+            .HasForeignKey(x => x.AuthorUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        var cardComment = modelBuilder.Entity<EntityCardComment>();
+        cardComment.HasKey(x => x.Id);
+        cardComment.Property(x => x.CardId).IsRequired();
+        cardComment.Property(x => x.AuthorUserId).IsRequired();
+        cardComment.Property(x => x.Text).HasMaxLength(4_000).IsRequired();
+        cardComment.Property(x => x.CreatedAtUtc).IsRequired();
+        cardComment.ToTable("CardComments");
+        cardComment.HasIndex(x => new { x.CardId, x.CreatedAtUtc, x.Id });
+        cardComment.HasIndex(x => x.AuthorUserId);
 
         var boardMember = modelBuilder.Entity<EntityBoardMember>();
         boardMember.HasKey(x => x.Id);

--- a/BoardOil.Ef/BoardOilDbContext.cs
+++ b/BoardOil.Ef/BoardOilDbContext.cs
@@ -92,7 +92,7 @@ public sealed class BoardOilDbContext(DbContextOptions<BoardOilDbContext> option
         archivedCard.Property(x => x.BoardId).IsRequired();
         archivedCard.Property(x => x.OriginalCardId).IsRequired();
         archivedCard.Property(x => x.ArchivedAtUtc).IsRequired();
-        archivedCard.Property(x => x.SnapshotJson).HasMaxLength(524_288).IsRequired();
+        archivedCard.Property(x => x.SnapshotJson).HasMaxLength(2_097_152).IsRequired();
         archivedCard.Property(x => x.SearchTitle).HasMaxLength(200).IsRequired();
         archivedCard.Property(x => x.SearchTagsJson).HasMaxLength(65_535).IsRequired();
         archivedCard.Property(x => x.SearchTextNormalised).HasMaxLength(65_535).IsRequired();

--- a/BoardOil.Ef/BoardOilDbContext.cs
+++ b/BoardOil.Ef/BoardOilDbContext.cs
@@ -165,12 +165,12 @@ public sealed class BoardOilDbContext(DbContextOptions<BoardOilDbContext> option
         user.HasMany(x => x.CardComments)
             .WithOne(x => x.AuthorUser)
             .HasForeignKey(x => x.AuthorUserId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.SetNull);
 
         var cardComment = modelBuilder.Entity<EntityCardComment>();
         cardComment.HasKey(x => x.Id);
         cardComment.Property(x => x.CardId).IsRequired();
-        cardComment.Property(x => x.AuthorUserId).IsRequired();
+        cardComment.Property(x => x.AuthorUserId).IsRequired(false);
         cardComment.Property(x => x.Text).HasMaxLength(4_000).IsRequired();
         cardComment.Property(x => x.CreatedAtUtc).IsRequired();
         cardComment.ToTable("CardComments");

--- a/BoardOil.Ef/Migrations/20260430195155_AddCardComments.Designer.cs
+++ b/BoardOil.Ef/Migrations/20260430195155_AddCardComments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BoardOil.Ef;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BoardOil.Ef.Migrations
 {
     [DbContext(typeof(BoardOilDbContext))]
-    partial class BoardOilDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430195155_AddCardComments")]
+    partial class AddCardComments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.6");

--- a/BoardOil.Ef/Migrations/20260430195155_AddCardComments.cs
+++ b/BoardOil.Ef/Migrations/20260430195155_AddCardComments.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BoardOil.Ef.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCardComments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CardComments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    CardId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AuthorUserId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Text = table.Column<string>(type: "TEXT", maxLength: 4000, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CardComments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CardComments_Cards_CardId",
+                        column: x => x.CardId,
+                        principalTable: "Cards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CardComments_Users_AuthorUserId",
+                        column: x => x.AuthorUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CardComments_AuthorUserId",
+                table: "CardComments",
+                column: "AuthorUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CardComments_CardId_CreatedAtUtc_Id",
+                table: "CardComments",
+                columns: new[] { "CardId", "CreatedAtUtc", "Id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CardComments");
+        }
+    }
+}

--- a/BoardOil.Ef/Migrations/20260502063514_MakeCardCommentAuthorOptional.Designer.cs
+++ b/BoardOil.Ef/Migrations/20260502063514_MakeCardCommentAuthorOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BoardOil.Ef;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BoardOil.Ef.Migrations
 {
     [DbContext(typeof(BoardOilDbContext))]
-    partial class BoardOilDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502063514_MakeCardCommentAuthorOptional")]
+    partial class MakeCardCommentAuthorOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.6");

--- a/BoardOil.Ef/Migrations/20260502063514_MakeCardCommentAuthorOptional.cs
+++ b/BoardOil.Ef/Migrations/20260502063514_MakeCardCommentAuthorOptional.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BoardOil.Ef.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeCardCommentAuthorOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CardComments_Users_AuthorUserId",
+                table: "CardComments");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorUserId",
+                table: "CardComments",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CardComments_Users_AuthorUserId",
+                table: "CardComments",
+                column: "AuthorUserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CardComments_Users_AuthorUserId",
+                table: "CardComments");
+
+            // Rollback safety: remove rows that rely on nullable author semantics
+            // before restoring AuthorUserId to a required foreign key.
+            migrationBuilder.Sql("DELETE FROM CardComments WHERE AuthorUserId IS NULL;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorUserId",
+                table: "CardComments",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CardComments_Users_AuthorUserId",
+                table: "CardComments",
+                column: "AuthorUserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/BoardOil.Ef/Migrations/20260502140828_IncreaseArchivedCardSnapshotLimit.Designer.cs
+++ b/BoardOil.Ef/Migrations/20260502140828_IncreaseArchivedCardSnapshotLimit.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BoardOil.Ef;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BoardOil.Ef.Migrations
 {
     [DbContext(typeof(BoardOilDbContext))]
-    partial class BoardOilDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502140828_IncreaseArchivedCardSnapshotLimit")]
+    partial class IncreaseArchivedCardSnapshotLimit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.6");

--- a/BoardOil.Ef/Migrations/20260502140828_IncreaseArchivedCardSnapshotLimit.cs
+++ b/BoardOil.Ef/Migrations/20260502140828_IncreaseArchivedCardSnapshotLimit.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BoardOil.Ef.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseArchivedCardSnapshotLimit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/BoardOil.Ef/Repositories/CardCommentRepository.cs
+++ b/BoardOil.Ef/Repositories/CardCommentRepository.cs
@@ -1,0 +1,17 @@
+using BoardOil.Abstractions.DataAccess;
+using BoardOil.Persistence.Abstractions.Card;
+using BoardOil.Persistence.Abstractions.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BoardOil.Ef.Repositories;
+
+public sealed class CardCommentRepository(IAmbientDbContextLocator ambientDbContextLocator)
+    : RepositoryBase<EntityCardComment>(ambientDbContextLocator), ICardCommentRepository
+{
+    public async Task<IReadOnlyList<EntityCardComment>> GetForCardOrderedAsync(int cardId) =>
+        await DbSet
+            .Where(x => x.CardId == cardId)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync();
+}

--- a/BoardOil.Ef/Repositories/CardCommentRepository.cs
+++ b/BoardOil.Ef/Repositories/CardCommentRepository.cs
@@ -11,7 +11,13 @@ public sealed class CardCommentRepository(IAmbientDbContextLocator ambientDbCont
     public async Task<IReadOnlyList<EntityCardComment>> GetForCardOrderedAsync(int cardId) =>
         await DbSet
             .Where(x => x.CardId == cardId)
+            .Include(x => x.AuthorUser)
             .OrderByDescending(x => x.CreatedAtUtc)
             .ThenByDescending(x => x.Id)
             .ToListAsync();
+
+    public Task<EntityCardComment?> GetByIdWithAuthorAsync(int id) =>
+        DbSet
+            .Include(x => x.AuthorUser)
+            .FirstOrDefaultAsync(x => x.Id == id);
 }

--- a/BoardOil.Ef/Repositories/CardCommentRepository.cs
+++ b/BoardOil.Ef/Repositories/CardCommentRepository.cs
@@ -16,6 +16,22 @@ public sealed class CardCommentRepository(IAmbientDbContextLocator ambientDbCont
             .ThenByDescending(x => x.Id)
             .ToListAsync();
 
+    public async Task<IReadOnlyList<EntityCardComment>> GetForCardsOrderedAsync(IReadOnlyList<int> cardIds)
+    {
+        if (cardIds.Count == 0)
+        {
+            return [];
+        }
+
+        return await DbSet
+            .Where(x => cardIds.Contains(x.CardId))
+            .Include(x => x.AuthorUser)
+            .OrderBy(x => x.CardId)
+            .ThenByDescending(x => x.CreatedAtUtc)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync();
+    }
+
     public Task<EntityCardComment?> GetByIdWithAuthorAsync(int id) =>
         DbSet
             .Include(x => x.AuthorUser)

--- a/BoardOil.Ef/Repositories/CardRepository.cs
+++ b/BoardOil.Ef/Repositories/CardRepository.cs
@@ -52,6 +52,7 @@ public sealed class CardRepository(IAmbientDbContextLocator ambientDbContextLoca
 
         return await DbSet
             .Where(x => ids.Contains(x.Id))
+            .AsSplitQuery()
             .Include(x => x.CardType)
             .Include(x => x.AssignedUser)
             .Include(x => x.CardTags)

--- a/BoardOil.Ef/Repositories/CardRepository.cs
+++ b/BoardOil.Ef/Repositories/CardRepository.cs
@@ -56,6 +56,8 @@ public sealed class CardRepository(IAmbientDbContextLocator ambientDbContextLoca
             .Include(x => x.AssignedUser)
             .Include(x => x.CardTags)
                 .ThenInclude(x => x.Tag)
+            .Include(x => x.Comments)
+                .ThenInclude(x => x.AuthorUser)
             .Include(x => x.BoardColumn)
             .ToListAsync();
     }

--- a/BoardOil.Mcp.Contracts/Models.cs
+++ b/BoardOil.Mcp.Contracts/Models.cs
@@ -67,7 +67,17 @@ public sealed record McpCardSnapshot(
     IReadOnlyList<string> TagNames,
     DateTime UpdatedAtUtc,
     int? AssignedUserId,
-    string? AssignedUserName);
+    string? AssignedUserName,
+    IReadOnlyList<McpCardCommentSnapshot> Comments);
+
+public sealed record McpCardCommentSnapshot(
+    int Id,
+    int CardId,
+    int AuthorUserId,
+    string Text,
+    DateTime CreatedAtUtc,
+    string? AuthorDisplayName,
+    string? AuthorImageRelativePath);
 
 public sealed record McpCardTagSnapshot(
     int Id,
@@ -157,6 +167,17 @@ public sealed record CardDeleteInput
     public int? Id { get; init; }
 }
 
+public sealed record CardCommentCreateInput
+{
+    public int? BoardId { get; init; }
+    public int? Id { get; init; }
+    public string Text { get; init; } = string.Empty;
+}
+
 public sealed record CardMutationOutput(
     McpCardSnapshot? Card,
+    string Outcome);
+
+public sealed record CardCommentMutationOutput(
+    McpCardCommentSnapshot? Comment,
     string Outcome);

--- a/BoardOil.Mcp.Contracts/Models.cs
+++ b/BoardOil.Mcp.Contracts/Models.cs
@@ -73,7 +73,7 @@ public sealed record McpCardSnapshot(
 public sealed record McpCardCommentSnapshot(
     int Id,
     int CardId,
-    int AuthorUserId,
+    int? AuthorUserId,
     string Text,
     DateTime CreatedAtUtc,
     string? AuthorDisplayName,

--- a/BoardOil.Mcp.Contracts/Schemas/ToolSchemas.cs
+++ b/BoardOil.Mcp.Contracts/Schemas/ToolSchemas.cs
@@ -102,6 +102,19 @@ public static class ToolSchemas
     }
     """;
 
+    public const string CardCommentCreateInput = """
+    {
+      "type": "object",
+      "properties": {
+        "boardId": { "type": "integer", "minimum": 1 },
+        "id": { "type": "integer", "minimum": 1 },
+        "text": { "type": "string", "minLength": 1, "maxLength": 4000 }
+      },
+      "required": ["boardId", "id", "text"],
+      "additionalProperties": false
+    }
+    """;
+
     public const string ObjectOutput = """
     {
       "type": "object"

--- a/BoardOil.Mcp.Contracts/ToolNames.cs
+++ b/BoardOil.Mcp.Contracts/ToolNames.cs
@@ -11,4 +11,5 @@ public static class ToolNames
     public const string CardUpdate = "card_update";
     public const string CardMove = "card_move";
     public const string CardDelete = "card_delete";
+    public const string CardCommentCreate = "card_comment_create";
 }

--- a/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
+++ b/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
@@ -6,4 +6,5 @@ namespace BoardOil.Persistence.Abstractions.Card;
 public interface ICardCommentRepository : IRepositoryBase<EntityCardComment>
 {
     Task<IReadOnlyList<EntityCardComment>> GetForCardOrderedAsync(int cardId);
+    Task<EntityCardComment?> GetByIdWithAuthorAsync(int id);
 }

--- a/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
+++ b/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
@@ -6,5 +6,6 @@ namespace BoardOil.Persistence.Abstractions.Card;
 public interface ICardCommentRepository : IRepositoryBase<EntityCardComment>
 {
     Task<IReadOnlyList<EntityCardComment>> GetForCardOrderedAsync(int cardId);
+    Task<IReadOnlyList<EntityCardComment>> GetForCardsOrderedAsync(IReadOnlyList<int> cardIds);
     Task<EntityCardComment?> GetByIdWithAuthorAsync(int id);
 }

--- a/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
+++ b/BoardOil.Persistence.Abstractions/Card/ICardCommentRepository.cs
@@ -1,0 +1,9 @@
+using BoardOil.Persistence.Abstractions.DataAccess;
+using BoardOil.Persistence.Abstractions.Entities;
+
+namespace BoardOil.Persistence.Abstractions.Card;
+
+public interface ICardCommentRepository : IRepositoryBase<EntityCardComment>
+{
+    Task<IReadOnlyList<EntityCardComment>> GetForCardOrderedAsync(int cardId);
+}

--- a/BoardOil.Persistence.Abstractions/Entities/EntityBoardCard.cs
+++ b/BoardOil.Persistence.Abstractions/Entities/EntityBoardCard.cs
@@ -16,4 +16,5 @@ public sealed class EntityBoardCard
     public EntityCardType CardType { get; set; } = null!;
     public EntityUser? AssignedUser { get; set; }
     public ICollection<EntityCardTag> CardTags { get; set; } = new List<EntityCardTag>();
+    public ICollection<EntityCardComment> Comments { get; set; } = new List<EntityCardComment>();
 }

--- a/BoardOil.Persistence.Abstractions/Entities/EntityCardComment.cs
+++ b/BoardOil.Persistence.Abstractions/Entities/EntityCardComment.cs
@@ -4,10 +4,10 @@ public sealed class EntityCardComment
 {
     public int Id { get; set; }
     public int CardId { get; set; }
-    public int AuthorUserId { get; set; }
+    public int? AuthorUserId { get; set; }
     public string Text { get; set; } = string.Empty;
     public DateTime CreatedAtUtc { get; set; }
 
     public EntityBoardCard Card { get; set; } = null!;
-    public EntityUser AuthorUser { get; set; } = null!;
+    public EntityUser? AuthorUser { get; set; }
 }

--- a/BoardOil.Persistence.Abstractions/Entities/EntityCardComment.cs
+++ b/BoardOil.Persistence.Abstractions/Entities/EntityCardComment.cs
@@ -1,0 +1,13 @@
+namespace BoardOil.Persistence.Abstractions.Entities;
+
+public sealed class EntityCardComment
+{
+    public int Id { get; set; }
+    public int CardId { get; set; }
+    public int AuthorUserId { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+
+    public EntityBoardCard Card { get; set; } = null!;
+    public EntityUser AuthorUser { get; set; } = null!;
+}

--- a/BoardOil.Persistence.Abstractions/Entities/EntityUser.cs
+++ b/BoardOil.Persistence.Abstractions/Entities/EntityUser.cs
@@ -17,4 +17,5 @@ public sealed class EntityUser
     public ICollection<EntityRefreshToken> RefreshTokens { get; set; } = new List<EntityRefreshToken>();
     public ICollection<EntityPersonalAccessToken> PersonalAccessTokens { get; set; } = new List<EntityPersonalAccessToken>();
     public ICollection<EntityBoardMember> BoardMemberships { get; set; } = new List<EntityBoardMember>();
+    public ICollection<EntityCardComment> CardComments { get; set; } = new List<EntityCardComment>();
 }

--- a/BoardOil.Services.Tests/ArchivedCardSnapshotSerialiserTests.cs
+++ b/BoardOil.Services.Tests/ArchivedCardSnapshotSerialiserTests.cs
@@ -28,6 +28,12 @@ public sealed class ArchivedCardSnapshotSerialiserTests
         Assert.Equal(card.Id, knownPayload.Payload.OriginalCardId);
         Assert.Equal(card.Title, knownPayload.Payload.Title);
         Assert.Equal(["Bug"], knownPayload.Payload.TagNames);
+        Assert.NotNull(knownPayload.Payload.Comments);
+        var firstComment = Assert.Single(knownPayload.Payload.Comments!);
+        Assert.Equal("Archived note", firstComment.Text);
+        Assert.Equal(card.CreatedAtUtc, firstComment.CreatedAtUtc);
+        Assert.Equal(11, firstComment.AuthorUserId);
+        Assert.Equal("[email protected]", firstComment.AuthorEmail);
     }
 
     [Fact]
@@ -66,6 +72,13 @@ public sealed class ArchivedCardSnapshotSerialiserTests
         Assert.Equal(card.Title, parsedCard.Title);
         Assert.Equal(card.Description, parsedCard.Description);
         Assert.Equal(["Bug"], parsedCard.TagNames);
+
+        var parsedSnapshot = ArchivedCardSnapshotSerialiser.TryBuildCurrentSnapshot(snapshotJson, out var snapshot, out error);
+        Assert.True(parsedSnapshot);
+        Assert.NotNull(snapshot);
+        var snapshotComment = Assert.Single(snapshot!.Comments);
+        Assert.Equal("Archived note", snapshotComment.Text);
+        Assert.Equal(11, snapshotComment.AuthorUserId);
     }
 
     private static EntityBoardCard BuildCardEntity()
@@ -104,6 +117,28 @@ public sealed class ArchivedCardSnapshotSerialiserTests
             SortKey = "B",
             CreatedAtUtc = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc),
             UpdatedAtUtc = new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc),
+            Comments =
+            [
+                new EntityCardComment
+                {
+                    Id = 99,
+                    AuthorUserId = 11,
+                    AuthorUser = new EntityUser
+                    {
+                        Id = 11,
+                        UserName = "author",
+                        DisplayName = "author",
+                        Email = "[email protected]",
+                        NormalisedEmail = "[email protected]",
+                        PasswordHash = "hash",
+                        Role = UserRole.Standard,
+                        IdentityType = UserIdentityType.User,
+                        IsActive = true
+                    },
+                    Text = "Archived note",
+                    CreatedAtUtc = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc)
+                }
+            ],
             CardTags =
             [
                 new EntityCardTag

--- a/BoardOil.Services.Tests/BoardExportServiceTests.cs
+++ b/BoardOil.Services.Tests/BoardExportServiceTests.cs
@@ -60,6 +60,20 @@ public sealed class BoardExportServiceTests : TestBaseDb
             CardId = card.Id,
             TagId = urgentTag.Id
         });
+        DbContextForArrange.CardComments.Add(new EntityCardComment
+        {
+            CardId = card.Id,
+            AuthorUserId = actor.Id,
+            Text = "Most recent comment",
+            CreatedAtUtc = now.AddMinutes(2)
+        });
+        DbContextForArrange.CardComments.Add(new EntityCardComment
+        {
+            CardId = card.Id,
+            AuthorUserId = null,
+            Text = "Older comment",
+            CreatedAtUtc = now.AddMinutes(1)
+        });
         var cardEntity = DbContextForArrange.Cards.Single(x => x.Id == card.Id);
         cardEntity.AssignedUserId = actor.Id;
         DbContextForArrange.ArchivedCards.Add(new EntityArchivedCard
@@ -128,10 +142,18 @@ public sealed class BoardExportServiceTests : TestBaseDb
         Assert.Equal("Story", exportedAssignedCard.CardTypeName);
         Assert.Equal(["Urgent"], exportedAssignedCard.TagNames);
         Assert.Equal(actor.Email, exportedAssignedCard.AssignedUserEmail);
+        Assert.NotNull(exportedAssignedCard.Comments);
+        Assert.Equal(2, exportedAssignedCard.Comments!.Count);
+        Assert.Equal("Most recent comment", exportedAssignedCard.Comments[0].Text);
+        Assert.Equal(actor.Email, exportedAssignedCard.Comments[0].AuthorEmail);
+        Assert.Equal("Older comment", exportedAssignedCard.Comments[1].Text);
+        Assert.Null(exportedAssignedCard.Comments[1].AuthorEmail);
         var exportedUnassignedCard = payload.Columns[0].Cards.Single(x => x.Title == unassignedCard.Title);
         Assert.Equal("Story", exportedUnassignedCard.CardTypeName);
         Assert.Equal([], exportedUnassignedCard.TagNames);
         Assert.Null(exportedUnassignedCard.AssignedUserEmail);
+        Assert.NotNull(exportedUnassignedCard.Comments);
+        Assert.Empty(exportedUnassignedCard.Comments!);
 
         var archiveEntry = archive.GetEntry("archive.json");
         Assert.NotNull(archiveEntry);

--- a/BoardOil.Services.Tests/BoardImportServiceTests.cs
+++ b/BoardOil.Services.Tests/BoardImportServiceTests.cs
@@ -82,6 +82,60 @@ public sealed class BoardImportServiceTests : TestBaseDb
     }
 
     [Fact]
+    public async Task ImportBoardPackageAsync_WhenCardIncludesComments_ShouldImportAndMapAuthorsByEmailBestEffort()
+    {
+        var actor = DbContextForArrange.Users.Single(x => x.Id == ActorUserId);
+        var manifest = BoardPackageContract.CreateManifest("0.3.0");
+        var payload = new BoardPackageBoardDto(
+            "Comment Import Board",
+            "Comment import board description",
+            [new BoardPackageCardTypeDto("Story", null, true)],
+            [],
+            [
+                new BoardPackageColumnDto(
+                    "Todo",
+                    [
+                        new BoardPackageCardDto(
+                            "Card with comments",
+                            "Description",
+                            "Story",
+                            [],
+                            null,
+                            [
+                                new BoardPackageCommentDto(
+                                    "  First imported comment  ",
+                                    new DateTime(2026, 05, 02, 8, 0, 0, DateTimeKind.Utc),
+                                    actor.Email.ToUpperInvariant()),
+                                new BoardPackageCommentDto(
+                                    "Second imported comment",
+                                    new DateTime(2026, 05, 02, 8, 1, 0, DateTimeKind.Utc),
+                                    "missing-user@example.com")
+                            ])
+                    ])
+            ]);
+
+        var service = ResolveService<IBoardPackageImportService>();
+        var result = await service.ImportBoardPackageAsync(
+            new ImportBoardPackageRequest(null, BuildBoardPackage(manifest, payload)),
+            ActorUserId);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        var boardId = result.Data!.Id;
+        var importedCard = DbContextForAssert.Cards.Single(x => x.BoardColumn.BoardId == boardId);
+        var importedComments = DbContextForAssert.CardComments
+            .Where(x => x.CardId == importedCard.Id)
+            .OrderBy(x => x.CreatedAtUtc)
+            .ToList();
+
+        Assert.Equal(2, importedComments.Count);
+        Assert.Equal("First imported comment", importedComments[0].Text);
+        Assert.Equal(actor.Id, importedComments[0].AuthorUserId);
+        Assert.Equal("Second imported comment", importedComments[1].Text);
+        Assert.Null(importedComments[1].AuthorUserId);
+    }
+
+    [Fact]
     public async Task ImportBoardPackageAsync_WhenAssignedUserEmailMatchesActiveUser_ShouldAssignCard()
     {
         var actor = DbContextForArrange.Users.Single(x => x.Id == ActorUserId);

--- a/BoardOil.Services.Tests/BoardImportServiceTests.cs
+++ b/BoardOil.Services.Tests/BoardImportServiceTests.cs
@@ -511,38 +511,6 @@ public sealed class BoardImportServiceTests : TestBaseDb
     }
 
     [Fact]
-    public async Task ImportBoardPackageAsync_WhenSchemaVersionIsOne_ShouldImportWithEmptyDescription()
-    {
-        var manifest = new BoardPackageManifestDto(
-            BoardPackageContract.PackageFormat,
-            1,
-            "0.2.0",
-            [new BoardPackageManifestEntryDto(BoardPackageContract.BoardEntryKind, BoardPackageContract.BoardEntryPath)]);
-        var boardPayloadV1Json =
-            """
-            {
-              "name": "Legacy Board",
-              "cardTypes": [
-                { "name": "Story", "emoji": null, "isSystem": true }
-              ],
-              "tags": [],
-              "columns": []
-            }
-            """;
-
-        var service = ResolveService<IBoardPackageImportService>();
-        var result = await service.ImportBoardPackageAsync(
-            new ImportBoardPackageRequest(null, BuildBoardPackageWithRawBoardPayload(manifest, boardPayloadV1Json)),
-            ActorUserId);
-
-        Assert.True(result.Success);
-        Assert.Equal(201, result.StatusCode);
-        Assert.NotNull(result.Data);
-        Assert.Equal("Legacy Board", result.Data!.Name);
-        Assert.Equal(string.Empty, result.Data.Description);
-    }
-
-    [Fact]
     public async Task ImportBoardPackageAsync_WhenSchemaVersionIsFuture_ShouldReturnBadRequestAndWriteNothing()
     {
         var manifest = new BoardPackageManifestDto(

--- a/BoardOil.Services.Tests/BoardImportServiceV1Tests.cs
+++ b/BoardOil.Services.Tests/BoardImportServiceV1Tests.cs
@@ -1,0 +1,68 @@
+using System.IO.Compression;
+using BoardOil.Abstractions.Board;
+using BoardOil.Contracts.Board;
+using BoardOil.Services.Board;
+using BoardOil.Services.Tests.Infrastructure;
+using Xunit;
+
+namespace BoardOil.Services.Tests;
+
+public sealed class BoardImportServiceV1Tests : TestBaseDb
+{
+    [Fact]
+    public async Task ImportBoardPackageAsync_WhenSchemaVersionIsOneRawPayload_ShouldImportWithEmptyDescription()
+    {
+        const string manifestJson =
+            """
+            {
+              "format": "boardoil-board-package",
+              "schemaVersion": 1,
+              "exportedByVersion": "0.2.0",
+              "entries": [
+                { "kind": "board", "path": "board.json" }
+              ]
+            }
+            """;
+        const string boardPayloadV1Json =
+            """
+            {
+              "name": "Legacy Board",
+              "cardTypes": [
+                { "name": "Story", "emoji": null, "isSystem": true }
+              ],
+              "tags": [],
+              "columns": []
+            }
+            """;
+
+        var service = ResolveService<IBoardPackageImportService>();
+        var result = await service.ImportBoardPackageAsync(
+            new ImportBoardPackageRequest(null, BuildBoardPackageWithRawEntries(manifestJson, boardPayloadV1Json)),
+            ActorUserId);
+
+        Assert.True(result.Success);
+        Assert.Equal(201, result.StatusCode);
+        Assert.NotNull(result.Data);
+        Assert.Equal("Legacy Board", result.Data!.Name);
+        Assert.Equal(string.Empty, result.Data.Description);
+    }
+
+    private static byte[] BuildBoardPackageWithRawEntries(string manifestJson, string boardJson)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteRawEntry(archive, BoardPackageContract.ManifestPath, manifestJson);
+            WriteRawEntry(archive, BoardPackageContract.BoardEntryPath, boardJson);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static void WriteRawEntry(ZipArchive archive, string path, string payload)
+    {
+        var entry = archive.CreateEntry(path, CompressionLevel.Optimal);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(payload);
+    }
+}

--- a/BoardOil.Services.Tests/CardArchiveServiceTests.cs
+++ b/BoardOil.Services.Tests/CardArchiveServiceTests.cs
@@ -203,6 +203,46 @@ public sealed class CardArchiveServiceTests : TestBaseDb
     }
 
     [Fact]
+    public async Task ArchiveCardAsync_WhenSnapshotWouldExceedLimit_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Archive me", "Keep this")
+            .Build();
+        var boardId = board.BoardId;
+        var cardId = board.GetCard("Todo", "Archive me").Id;
+        var now = DateTime.UtcNow;
+        var largeCommentText = new string('x', 4_000);
+        for (var i = 0; i < 540; i++)
+        {
+            DbContextForArrange.CardComments.Add(new()
+            {
+                CardId = cardId,
+                AuthorUserId = ActorUserId,
+                Text = largeCommentText,
+                CreatedAtUtc = now.AddSeconds(i)
+            });
+        }
+
+        await DbContextForArrange.SaveChangesAsync();
+        var service = ResolveService<ICardArchiveService>();
+
+        // Act
+        var result = await service.ArchiveCardAsync(boardId, cardId, ActorUserId);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("This card is too large to archive.", result.Message);
+
+        var liveExists = await DbContextForAssert.Cards.AnyAsync(x => x.Id == cardId);
+        Assert.True(liveExists);
+        var archivedCount = await DbContextForAssert.Set<ArchivedCardEntity>().CountAsync();
+        Assert.Equal(0, archivedCount);
+    }
+
+    [Fact]
     public async Task GetArchivedCardsAsync_WhenMultipleCardsArchived_ShouldReturnNewestFirst()
     {
         // Arrange

--- a/BoardOil.Services.Tests/CardArchiveServiceTests.cs
+++ b/BoardOil.Services.Tests/CardArchiveServiceTests.cs
@@ -61,6 +61,57 @@ public sealed class CardArchiveServiceTests : TestBaseDb
     }
 
     [Fact]
+    public async Task ArchiveCardAsync_ThenUnarchiveCardAsync_ShouldRestoreCommentsWithBestEffortAuthorLinkage()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Archive me", "Keep this")
+            .Build();
+        var boardId = board.BoardId;
+        var cardId = board.GetCard("Todo", "Archive me").Id;
+        var now = DateTime.UtcNow;
+        DbContextForArrange.CardComments.Add(new()
+        {
+            CardId = cardId,
+            AuthorUserId = ActorUserId,
+            Text = "Comment from known user",
+            CreatedAtUtc = now
+        });
+        DbContextForArrange.CardComments.Add(new()
+        {
+            CardId = cardId,
+            AuthorUserId = null,
+            Text = "Comment from unknown user",
+            CreatedAtUtc = now.AddSeconds(1)
+        });
+        await DbContextForArrange.SaveChangesAsync();
+
+        var service = ResolveService<ICardArchiveService>();
+
+        // Act
+        var archiveResult = await service.ArchiveCardAsync(boardId, cardId, ActorUserId);
+        Assert.True(archiveResult.Success);
+        Assert.NotNull(archiveResult.Data);
+
+        var unarchiveResult = await service.UnarchiveCardAsync(boardId, archiveResult.Data!.Id, ActorUserId);
+
+        // Assert
+        Assert.True(unarchiveResult.Success);
+        Assert.NotNull(unarchiveResult.Data);
+        var restoredCardId = unarchiveResult.Data!.Id;
+        var restoredComments = await DbContextForAssert.CardComments
+            .Where(x => x.CardId == restoredCardId)
+            .OrderBy(x => x.CreatedAtUtc)
+            .ToListAsync();
+        Assert.Equal(2, restoredComments.Count);
+        Assert.Equal("Comment from known user", restoredComments[0].Text);
+        Assert.Equal(ActorUserId, restoredComments[0].AuthorUserId);
+        Assert.Equal("Comment from unknown user", restoredComments[1].Text);
+        Assert.Null(restoredComments[1].AuthorUserId);
+    }
+
+    [Fact]
     public async Task ArchiveCardsAsync_WhenCardsExist_ShouldArchiveAllAndReturnSummary()
     {
         // Arrange

--- a/BoardOil.Services.Tests/CardCommentServiceTests.cs
+++ b/BoardOil.Services.Tests/CardCommentServiceTests.cs
@@ -1,5 +1,6 @@
 using BoardOil.Services.Card;
 using BoardOil.Services.Tests.Infrastructure;
+using BoardOil.Abstractions;
 using BoardOil.Abstractions.Card;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -18,6 +19,7 @@ public sealed class CardCommentServiceTests : TestBaseDb
             .Build();
         var cardId = board.GetCard("Todo", "Task A").Id;
         var service = ResolveService<ICardCommentService>();
+        var boardEvents = Assert.IsType<TestBoardEvents>(ResolveService<IBoardEvents>());
 
         // Act
         var result = await service.CreateCommentAsync(board.BoardId, cardId, new("  First comment  "), ActorUserId);
@@ -33,6 +35,11 @@ public sealed class CardCommentServiceTests : TestBaseDb
         Assert.Equal(cardId, stored.CardId);
         Assert.Equal(ActorUserId, stored.AuthorUserId);
         Assert.Equal("First comment", stored.Text);
+
+        var realtimeEvent = Assert.Single(boardEvents.CommentCreatedEvents);
+        Assert.Equal(board.BoardId, realtimeEvent.BoardId);
+        Assert.Equal(cardId, realtimeEvent.Comment.CardId);
+        Assert.Equal("First comment", realtimeEvent.Comment.Text);
     }
 
     [Fact]

--- a/BoardOil.Services.Tests/CardCommentServiceTests.cs
+++ b/BoardOil.Services.Tests/CardCommentServiceTests.cs
@@ -1,0 +1,73 @@
+using BoardOil.Services.Card;
+using BoardOil.Services.Tests.Infrastructure;
+using BoardOil.Abstractions.Card;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BoardOil.Services.Tests;
+
+public sealed class CardCommentServiceTests : TestBaseDb
+{
+    [Fact]
+    public async Task CreateCommentAsync_WhenValid_ShouldPersistAndReturnCreated()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Task A", "Desc")
+            .Build();
+        var cardId = board.GetCard("Todo", "Task A").Id;
+        var service = ResolveService<ICardCommentService>();
+
+        // Act
+        var result = await service.CreateCommentAsync(board.BoardId, cardId, new("  First comment  "), ActorUserId);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(201, result.StatusCode);
+        Assert.NotNull(result.Data);
+        Assert.Equal(cardId, result.Data!.CardId);
+        Assert.Equal("First comment", result.Data.Text);
+
+        var stored = await DbContextForAssert.CardComments.SingleAsync();
+        Assert.Equal(cardId, stored.CardId);
+        Assert.Equal(ActorUserId, stored.AuthorUserId);
+        Assert.Equal("First comment", stored.Text);
+    }
+
+    [Fact]
+    public async Task GetCommentsAsync_WhenCommentsExist_ShouldReturnCreatedOrder()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Task A", "Desc")
+            .Build();
+        var cardId = board.GetCard("Todo", "Task A").Id;
+        var now = DateTime.UtcNow;
+        DbContextForArrange.CardComments.Add(new()
+        {
+            CardId = cardId,
+            AuthorUserId = ActorUserId,
+            Text = "A",
+            CreatedAtUtc = now
+        });
+        DbContextForArrange.CardComments.Add(new()
+        {
+            CardId = cardId,
+            AuthorUserId = ActorUserId,
+            Text = "B",
+            CreatedAtUtc = now.AddSeconds(1)
+        });
+        await DbContextForArrange.SaveChangesAsync();
+        var service = ResolveService<ICardCommentService>();
+
+        // Act
+        var result = await service.GetCommentsAsync(board.BoardId, cardId, ActorUserId);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(["B", "A"], result.Data!.Select(x => x.Text).ToArray());
+    }
+}

--- a/BoardOil.Services.Tests/CardCommentServiceTests.cs
+++ b/BoardOil.Services.Tests/CardCommentServiceTests.cs
@@ -70,4 +70,35 @@ public sealed class CardCommentServiceTests : TestBaseDb
         Assert.NotNull(result.Data);
         Assert.Equal(["B", "A"], result.Data!.Select(x => x.Text).ToArray());
     }
+
+    [Fact]
+    public async Task GetCommentsAsync_WhenAuthorCannotBeResolved_ShouldReturnUnknownUser()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Task A", "Desc")
+            .Build();
+        var cardId = board.GetCard("Todo", "Task A").Id;
+        DbContextForArrange.CardComments.Add(new()
+        {
+            CardId = cardId,
+            AuthorUserId = null,
+            Text = "Orphaned",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+        await DbContextForArrange.SaveChangesAsync();
+        var service = ResolveService<ICardCommentService>();
+
+        // Act
+        var result = await service.GetCommentsAsync(board.BoardId, cardId, ActorUserId);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        var comment = Assert.Single(result.Data!);
+        Assert.Null(comment.AuthorUserId);
+        Assert.Equal("Unknown user", comment.AuthorDisplayName);
+        Assert.Null(comment.AuthorImageRelativePath);
+    }
 }

--- a/BoardOil.Services.Tests/CardUnarchiveServiceV1Tests.cs
+++ b/BoardOil.Services.Tests/CardUnarchiveServiceV1Tests.cs
@@ -48,6 +48,56 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
     }
 
     [Fact]
+    public async Task UnarchiveCardAsync_WhenArchivedCardV1ContainsComments_ShouldRestoreComments()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .Build();
+        var boardId = board.BoardId;
+        var todoColumnId = board.GetColumn("Todo").Id;
+        var capturedAtUtc = new DateTime(2026, 4, 26, 12, 0, 0, DateTimeKind.Utc);
+        var archivedCard = await SeedArchivedCardV1Async(
+            boardId,
+            originalCardId: 777,
+            boardColumnId: todoColumnId,
+            cardTypeId: await GetSystemCardTypeIdForBoardAsync(boardId),
+            title: "Archived with comments",
+            description: "Desc",
+            capturedAtUtc: capturedAtUtc,
+            comments:
+            [
+                new ArchivedCardSnapshotCommentV1Payload(
+                    "Known author comment",
+                    capturedAtUtc,
+                    ActorUserId,
+                    null),
+                new ArchivedCardSnapshotCommentV1Payload(
+                    "Unknown author comment",
+                    capturedAtUtc.AddMinutes(1),
+                    null,
+                    null)
+            ]);
+        var service = ResolveService<ICardArchiveService>();
+
+        // Act
+        var unarchiveResult = await service.UnarchiveCardAsync(boardId, archivedCard.Id, ActorUserId);
+
+        // Assert
+        Assert.True(unarchiveResult.Success);
+        Assert.NotNull(unarchiveResult.Data);
+        var restoredComments = await DbContextForAssert.CardComments
+            .Where(x => x.CardId == unarchiveResult.Data!.Id)
+            .OrderBy(x => x.CreatedAtUtc)
+            .ToListAsync();
+        Assert.Equal(2, restoredComments.Count);
+        Assert.Equal("Known author comment", restoredComments[0].Text);
+        Assert.Equal(ActorUserId, restoredComments[0].AuthorUserId);
+        Assert.Equal("Unknown author comment", restoredComments[1].Text);
+        Assert.Null(restoredComments[1].AuthorUserId);
+    }
+
+    [Fact]
     public async Task UnarchiveCardAsync_WhenArchivedCardMissing_ShouldReturnNotFound()
     {
         // Arrange
@@ -172,9 +222,11 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
         int boardColumnId,
         int cardTypeId,
         string title,
-        string description)
+        string description,
+        DateTime? capturedAtUtc = null,
+        IReadOnlyList<ArchivedCardSnapshotCommentV1Payload>? comments = null)
     {
-        var archivedAtUtc = new DateTime(2026, 4, 26, 12, 0, 0, DateTimeKind.Utc);
+        var archivedAtUtc = capturedAtUtc ?? new DateTime(2026, 4, 26, 12, 0, 0, DateTimeKind.Utc);
         var snapshotJson = CreateSnapshotJsonV1(
             boardId,
             originalCardId,
@@ -182,7 +234,8 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
             cardTypeId,
             title,
             description,
-            archivedAtUtc);
+            archivedAtUtc,
+            comments);
         var archivedCard = DbContextForArrange.Set<ArchivedCardEntity>().Add(new ArchivedCardEntity
         {
             BoardId = boardId,
@@ -204,7 +257,8 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
         int cardTypeId,
         string title,
         string description,
-        DateTime capturedAtUtc)
+        DateTime capturedAtUtc,
+        IReadOnlyList<ArchivedCardSnapshotCommentV1Payload>? comments = null)
     {
         var payload = new ArchivedCardSnapshotV1Payload(
             boardId,
@@ -221,7 +275,8 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
             [],
             capturedAtUtc,
             capturedAtUtc,
-            null);
+            null,
+            comments);
         var envelope = new ArchivedCardSnapshotEnvelopeV1(
             ArchivedCardSnapshotSerialiser.SchemaName,
             1,

--- a/BoardOil.Services.Tests/CardUnarchiveServiceV1Tests.cs
+++ b/BoardOil.Services.Tests/CardUnarchiveServiceV1Tests.cs
@@ -98,6 +98,46 @@ public sealed class CardUnarchiveServiceV1Tests : TestBaseDb
     }
 
     [Fact]
+    public async Task UnarchiveCardAsync_WhenArchivedCardV1CommentAuthorFallsBackToEmail_ShouldRelinkAuthor()
+    {
+        // Arrange
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .Build();
+        var boardId = board.BoardId;
+        var todoColumnId = board.GetColumn("Todo").Id;
+        var capturedAtUtc = new DateTime(2026, 4, 26, 12, 0, 0, DateTimeKind.Utc);
+        var archivedCard = await SeedArchivedCardV1Async(
+            boardId,
+            originalCardId: 778,
+            boardColumnId: todoColumnId,
+            cardTypeId: await GetSystemCardTypeIdForBoardAsync(boardId),
+            title: "Archived with email-linked comment",
+            description: "Desc",
+            capturedAtUtc: capturedAtUtc,
+            comments:
+            [
+                new ArchivedCardSnapshotCommentV1Payload(
+                    "Email linked comment",
+                    capturedAtUtc,
+                    999_999,
+                    "ACTOR@LOCALHOST")
+            ]);
+        var service = ResolveService<ICardArchiveService>();
+
+        // Act
+        var unarchiveResult = await service.UnarchiveCardAsync(boardId, archivedCard.Id, ActorUserId);
+
+        // Assert
+        Assert.True(unarchiveResult.Success);
+        Assert.NotNull(unarchiveResult.Data);
+        var restoredComment = await DbContextForAssert.CardComments
+            .SingleAsync(x => x.CardId == unarchiveResult.Data!.Id);
+        Assert.Equal("Email linked comment", restoredComment.Text);
+        Assert.Equal(ActorUserId, restoredComment.AuthorUserId);
+    }
+
+    [Fact]
     public async Task UnarchiveCardAsync_WhenArchivedCardMissing_ShouldReturnNotFound()
     {
         // Arrange

--- a/BoardOil.Services.Tests/Infrastructure/TestBoardEvents.cs
+++ b/BoardOil.Services.Tests/Infrastructure/TestBoardEvents.cs
@@ -6,6 +6,8 @@ namespace BoardOil.Services.Tests.Infrastructure;
 
 public sealed class TestBoardEvents : IBoardEvents
 {
+    public readonly List<(int BoardId, CardCommentDto Comment)> CommentCreatedEvents = [];
+
     public Task ColumnCreatedAsync(int boardId, ColumnDto column) => Task.CompletedTask;
     public Task ColumnUpdatedAsync(int boardId, ColumnDto column) => Task.CompletedTask;
     public Task ColumnDeletedAsync(int boardId, int columnId) => Task.CompletedTask;
@@ -14,5 +16,11 @@ public sealed class TestBoardEvents : IBoardEvents
     public Task CardUpdatedAsync(int boardId, CardDto card) => Task.CompletedTask;
     public Task CardDeletedAsync(int boardId, int cardId) => Task.CompletedTask;
     public Task CardMovedAsync(int boardId, CardDto card) => Task.CompletedTask;
+    public Task CommentCreatedAsync(int boardId, CardCommentDto comment)
+    {
+        CommentCreatedEvents.Add((boardId, comment));
+        return Task.CompletedTask;
+    }
+
     public Task ResyncRequestedAsync(int boardId) => Task.CompletedTask;
 }

--- a/BoardOil.Services.Tests/UserAdminServiceTests.cs
+++ b/BoardOil.Services.Tests/UserAdminServiceTests.cs
@@ -234,6 +234,36 @@ public sealed class UserAdminServiceTests : TestBaseDb
         Assert.NotNull(await DbContextForAssert.Users.SingleOrDefaultAsync(x => x.Id == actorAdmin.Id));
     }
 
+    [Fact]
+    public async Task DeleteUserAsync_WhenUserAuthoredComments_ShouldPreserveCommentsAndClearAuthor()
+    {
+        // Arrange
+        var targetAdmin = await AddUserAsync("target-admin", "target-admin@localhost", "Password1234!", UserRole.Admin, isActive: true);
+        var board = CreateBoard("BoardOil")
+            .AddColumn("Todo")
+            .AddCard("Task A", "Desc")
+            .Build();
+        var cardId = board.GetCard("Todo", "Task A").Id;
+        DbContextForArrange.CardComments.Add(new EntityCardComment
+        {
+            CardId = cardId,
+            AuthorUserId = targetAdmin.Id,
+            Text = "Preserve me",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+        await DbContextForArrange.SaveChangesAsync();
+        var service = ResolveService<IUserAdminService>();
+
+        // Act
+        var result = await service.DeleteUserAsync(targetAdmin.Id, ActorUserId);
+
+        // Assert
+        Assert.True(result.Success);
+        var storedComment = await DbContextForAssert.CardComments.SingleAsync();
+        Assert.Equal("Preserve me", storedComment.Text);
+        Assert.Null(storedComment.AuthorUserId);
+    }
+
     private async Task RemoveAllUsersAsync()
     {
         DbContextForArrange.Users.RemoveRange(DbContextForArrange.Users);

--- a/BoardOil.Services/Board/BoardExportService.cs
+++ b/BoardOil.Services/Board/BoardExportService.cs
@@ -18,6 +18,7 @@ public sealed class BoardExportService(
     IBoardRepository boardRepository,
     IColumnRepository columnRepository,
     ICardRepository cardRepository,
+    ICardCommentRepository cardCommentRepository,
     IArchivedCardRepository archivedCardRepository,
     ICardTypeRepository cardTypeRepository,
     ITagRepository tagRepository,
@@ -50,9 +51,21 @@ public sealed class BoardExportService(
         var columns = await columnRepository.GetColumnsInBoardOrderedAsync(boardId);
         var columnIds = columns.Select(x => x.Id).ToList();
         var cards = await cardRepository.GetCardsForColumnsOrderedAsync(columnIds);
+        var cardIds = cards.Select(x => x.Id).ToList();
+        var comments = await cardCommentRepository.GetForCardsOrderedAsync(cardIds);
         var archivedCards = await archivedCardRepository.ListForExportAsync(boardId);
         var cardTypes = await cardTypeRepository.GetAllForBoardAsync(boardId);
         var tags = await tagRepository.GetAllForBoardAsync(boardId);
+        var commentsByCardId = comments
+            .GroupBy(x => x.CardId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<BoardPackageCommentDto>)group
+                    .Select(comment => new BoardPackageCommentDto(
+                        comment.Text,
+                        comment.CreatedAtUtc,
+                        comment.AuthorUser?.Email))
+                    .ToList());
 
         var cardsByColumnId = cards
             .GroupBy(x => x.BoardColumnId)
@@ -68,7 +81,8 @@ public sealed class BoardExportService(
                             .OrderBy(cardTag => cardTag.Tag.Name)
                             .Select(cardTag => cardTag.Tag.Name)
                             .ToList(),
-                        card.AssignedUser?.Email))
+                        card.AssignedUser?.Email,
+                        commentsByCardId.GetValueOrDefault(card.Id, [])))
                     .ToList());
 
         var boardPayload = new BoardPackageBoardDto(

--- a/BoardOil.Services/Board/BoardPackageImportService.cs
+++ b/BoardOil.Services/Board/BoardPackageImportService.cs
@@ -23,6 +23,7 @@ public sealed class BoardPackageImportService(
     IBoardRepository boardRepository,
     IColumnRepository columnRepository,
     ICardRepository cardRepository,
+    ICardCommentRepository cardCommentRepository,
     IArchivedCardRepository archivedCardRepository,
     ICardTypeRepository cardTypeRepository,
     ITagRepository tagRepository,
@@ -34,6 +35,7 @@ public sealed class BoardPackageImportService(
     private const int MaxColumnNameLength = 200;
     private const int MaxCardTitleLength = 200;
     private const int MaxCardDescriptionLength = 20_000;
+    private const int MaxCardCommentLength = 4_000;
     private const int MaxTagNameLength = 40;
     private const int MaxCardTypeNameLength = 40;
     private const int MaxArchiveTitleLength = 200;
@@ -141,6 +143,7 @@ public sealed class BoardPackageImportService(
         var createdColumns = new List<EntityBoardColumn>(importPlan.Columns.Count);
         var createdCardsByColumn = new Dictionary<EntityBoardColumn, List<EntityBoardCard>>();
         var assigneeByNormalisedEmail = new Dictionary<string, EntityUser?>(StringComparer.Ordinal);
+        var commentAuthorByNormalisedEmail = new Dictionary<string, EntityUser?>(StringComparer.Ordinal);
         string? previousColumnSortKey = null;
 
         foreach (var importedColumn in importPlan.Columns)
@@ -207,6 +210,21 @@ public sealed class BoardPackageImportService(
                 cardRepository.Add(createdCard);
                 createdCards.Add(createdCard);
                 previousCardSortKey = cardSortKey;
+
+                foreach (var importedComment in importedCard.Comments)
+                {
+                    var commentAuthor = await ResolveImportedCommentAuthorAsync(
+                        importedComment.AuthorNormalisedEmail,
+                        commentAuthorByNormalisedEmail);
+                    cardCommentRepository.Add(new EntityCardComment
+                    {
+                        Card = createdCard,
+                        AuthorUserId = commentAuthor?.Id,
+                        AuthorUser = commentAuthor,
+                        Text = importedComment.Text,
+                        CreatedAtUtc = importedComment.CreatedAtUtc
+                    });
+                }
             }
 
             createdCardsByColumn.Add(createdColumn, createdCards);
@@ -437,6 +455,7 @@ public sealed class BoardPackageImportService(
                 return new ParseBoardPayloadResult(boardPayload, null);
             }
             case 2:
+            case 3:
             {
                 var boardPayload = JsonSerializer.Deserialize<BoardPackageBoardDto>(boardJson, JsonOptions);
                 return new ParseBoardPayloadResult(boardPayload, null);
@@ -456,6 +475,7 @@ public sealed class BoardPackageImportService(
         {
             case 1:
             case 2:
+            case 3:
             {
                 var archivePayload = JsonSerializer.Deserialize<BoardPackageArchiveDto>(archiveJson, JsonOptions);
                 if (archivePayload is null)
@@ -729,6 +749,10 @@ public sealed class BoardPackageImportService(
                     }
 
                     var canonicalTagNames = ValidateAndCanonicaliseCardTagNames(importedCard.TagNames, $"{cardPropertyPrefix}.tagNames", validationErrors);
+                    var plannedComments = ValidateAndCanonicaliseCardComments(
+                        importedCard.Comments,
+                        $"{cardPropertyPrefix}.comments",
+                        validationErrors);
 
                     if (validationErrors.Any(x => x.Property.StartsWith(cardPropertyPrefix, StringComparison.Ordinal)))
                     {
@@ -740,7 +764,8 @@ public sealed class BoardPackageImportService(
                         cardDescription,
                         cardTypeValidation.NormalisedName,
                         canonicalTagNames,
-                        ResolveAssignedUserNormalisedEmail(importedCard.AssignedUserEmail)));
+                        ResolveNormalisedEmailOrNull(importedCard.AssignedUserEmail),
+                        plannedComments));
                 }
 
                 if (validationErrors.Any(x => x.Property.StartsWith(columnPropertyPrefix, StringComparison.Ordinal)))
@@ -924,6 +949,58 @@ public sealed class BoardPackageImportService(
         return canonicalTagNames;
     }
 
+    private static IReadOnlyList<CommentImportDefinition> ValidateAndCanonicaliseCardComments(
+        IReadOnlyList<BoardPackageCommentDto>? comments,
+        string propertyPrefix,
+        ICollection<ValidationError> validationErrors)
+    {
+        if (comments is null)
+        {
+            return [];
+        }
+
+        var canonicalComments = new List<CommentImportDefinition>(comments.Count);
+        for (var commentIndex = 0; commentIndex < comments.Count; commentIndex++)
+        {
+            var importedComment = comments[commentIndex];
+            var commentPropertyPrefix = $"{propertyPrefix}[{commentIndex}]";
+            if (importedComment is null)
+            {
+                validationErrors.Add(new ValidationError(commentPropertyPrefix, "Comment entry is required."));
+                continue;
+            }
+
+            var canonicalText = importedComment.Text?.Trim() ?? string.Empty;
+            if (canonicalText.Length == 0)
+            {
+                validationErrors.Add(new ValidationError($"{commentPropertyPrefix}.text", "Comment text is required."));
+            }
+            else if (canonicalText.Length > MaxCardCommentLength)
+            {
+                validationErrors.Add(new ValidationError(
+                    $"{commentPropertyPrefix}.text",
+                    $"Comment text must be {MaxCardCommentLength} characters or fewer."));
+            }
+
+            if (importedComment.CreatedAtUtc == default)
+            {
+                validationErrors.Add(new ValidationError($"{commentPropertyPrefix}.createdAtUtc", "Comment created time is required."));
+            }
+
+            if (validationErrors.Any(x => x.Property.StartsWith(commentPropertyPrefix, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            canonicalComments.Add(new CommentImportDefinition(
+                canonicalText,
+                importedComment.CreatedAtUtc,
+                ResolveNormalisedEmailOrNull(importedComment.AuthorEmail)));
+        }
+
+        return canonicalComments;
+    }
+
     private static TagNameValidationResult ValidateTagName(string? rawTagName, string property)
     {
         if (string.IsNullOrWhiteSpace(rawTagName))
@@ -999,16 +1076,16 @@ public sealed class BoardPackageImportService(
         return stylePropertiesJson.Trim();
     }
 
-    private static string? ResolveAssignedUserNormalisedEmail(string? assignedUserEmail)
+    private static string? ResolveNormalisedEmailOrNull(string? emailAddress)
     {
-        if (string.IsNullOrWhiteSpace(assignedUserEmail))
+        if (string.IsNullOrWhiteSpace(emailAddress))
         {
             return null;
         }
 
-        return EmailAddressRules.Validate(assignedUserEmail, "assignedUserEmail").Count > 0
+        return EmailAddressRules.Validate(emailAddress, "email").Count > 0
             ? null
-            : EmailAddressRules.TryNormalise(assignedUserEmail);
+            : EmailAddressRules.TryNormalise(emailAddress);
     }
 
     private async Task<EntityUser?> ResolveImportedAssignedUserAsync(
@@ -1029,6 +1106,25 @@ public sealed class BoardPackageImportService(
         var resolvedAssignee = user is { IsActive: true } ? user : null;
         assigneeByNormalisedEmail[assignedUserNormalisedEmail] = resolvedAssignee;
         return resolvedAssignee;
+    }
+
+    private async Task<EntityUser?> ResolveImportedCommentAuthorAsync(
+        string? authorNormalisedEmail,
+        IDictionary<string, EntityUser?> authorByNormalisedEmail)
+    {
+        if (string.IsNullOrWhiteSpace(authorNormalisedEmail))
+        {
+            return null;
+        }
+
+        if (authorByNormalisedEmail.TryGetValue(authorNormalisedEmail, out var cachedAuthor))
+        {
+            return cachedAuthor;
+        }
+
+        var user = await userRepository.GetByNormalisedEmailAsync(authorNormalisedEmail);
+        authorByNormalisedEmail[authorNormalisedEmail] = user;
+        return user;
     }
 
     private async Task<int> ResolveNextImportedArchivedOriginalCardIdAsync()
@@ -1110,7 +1206,13 @@ public sealed class BoardPackageImportService(
         string Description,
         string CardTypeNormalisedName,
         IReadOnlyList<string> TagNames,
-        string? AssignedUserNormalisedEmail);
+        string? AssignedUserNormalisedEmail,
+        IReadOnlyList<CommentImportDefinition> Comments);
+
+    private sealed record CommentImportDefinition(
+        string Text,
+        DateTime CreatedAtUtc,
+        string? AuthorNormalisedEmail);
 
     private sealed record ArchivedCardImportDefinition(
         int OriginalCardId,

--- a/BoardOil.Services/Board/BoardPackageImportService.cs
+++ b/BoardOil.Services/Board/BoardPackageImportService.cs
@@ -439,23 +439,7 @@ public sealed class BoardPackageImportService(
         switch (schemaVersion)
         {
             case 1:
-            {
-                var legacyBoardPayload = JsonSerializer.Deserialize<BoardPackageBoardV1Dto>(boardJson, JsonOptions);
-                if (legacyBoardPayload is null)
-                {
-                    return new ParseBoardPayloadResult(null, null);
-                }
-
-                var boardPayload = new BoardPackageBoardDto(
-                    legacyBoardPayload.Name,
-                    string.Empty,
-                    legacyBoardPayload.CardTypes,
-                    legacyBoardPayload.Tags,
-                    legacyBoardPayload.Columns);
-                return new ParseBoardPayloadResult(boardPayload, null);
-            }
             case 2:
-            case 3:
             {
                 var boardPayload = JsonSerializer.Deserialize<BoardPackageBoardDto>(boardJson, JsonOptions);
                 return new ParseBoardPayloadResult(boardPayload, null);
@@ -475,7 +459,6 @@ public sealed class BoardPackageImportService(
         {
             case 1:
             case 2:
-            case 3:
             {
                 var archivePayload = JsonSerializer.Deserialize<BoardPackageArchiveDto>(archiveJson, JsonOptions);
                 if (archivePayload is null)
@@ -1176,12 +1159,6 @@ public sealed class BoardPackageImportService(
         IReadOnlyList<TagImportDefinition> TagDefinitions,
         IReadOnlyList<ColumnImportDefinition> Columns,
         IReadOnlyList<ArchivedCardImportDefinition> ArchivedCards);
-
-    private sealed record BoardPackageBoardV1Dto(
-        string Name,
-        IReadOnlyList<BoardPackageCardTypeDto> CardTypes,
-        IReadOnlyList<BoardPackageTagDto> Tags,
-        IReadOnlyList<BoardPackageColumnDto> Columns);
 
     private sealed record CardTypeImportDefinition(
         string Name,

--- a/BoardOil.Services/Board/BoardPackageImportService.cs
+++ b/BoardOil.Services/Board/BoardPackageImportService.cs
@@ -39,7 +39,7 @@ public sealed class BoardPackageImportService(
     private const int MaxTagNameLength = 40;
     private const int MaxCardTypeNameLength = 40;
     private const int MaxArchiveTitleLength = 200;
-    private const int MaxArchiveSnapshotJsonBytes = 524_288;
+    private const int MaxArchiveSnapshotJsonBytes = 2_097_152;
     private const int MaxArchiveSearchTagsJsonLength = 65_535;
     private const int MaxArchiveSearchTextNormalisedLength = 65_535;
 

--- a/BoardOil.Services/Card/ArchivedCardSnapshotSerialiser.cs
+++ b/BoardOil.Services/Card/ArchivedCardSnapshotSerialiser.cs
@@ -34,7 +34,16 @@ public static class ArchivedCardSnapshotSerialiser
                 .ToList(),
             card.CreatedAtUtc,
             card.UpdatedAtUtc,
-            card.AssignedUserId);
+            card.AssignedUserId,
+            card.Comments
+                .OrderBy(x => x.CreatedAtUtc)
+                .ThenBy(x => x.Id)
+                .Select(x => new ArchivedCardSnapshotCommentV1Payload(
+                    x.Text,
+                    x.CreatedAtUtc,
+                    x.AuthorUserId,
+                    x.AuthorUser?.Email))
+                .ToList());
 
         var envelope = new ArchivedCardSnapshotEnvelopeV1(
             SchemaName,
@@ -130,6 +139,22 @@ public static class ArchivedCardSnapshotSerialiser
     public static bool TryBuildCurrentCardDto(string snapshotJson, out CardDto? card, out string? error)
     {
         card = null;
+        var parsed = TryBuildCurrentSnapshot(snapshotJson, out var snapshot, out error);
+        if (!parsed || snapshot is null)
+        {
+            return false;
+        }
+
+        card = snapshot.Card;
+        return true;
+    }
+
+    public static bool TryBuildCurrentSnapshot(
+        string snapshotJson,
+        out ArchivedCardSnapshotCurrentDto? snapshot,
+        out string? error)
+    {
+        snapshot = null;
         var parsed = TryReadKnownPayload(snapshotJson, out var knownPayload, out error);
         if (!parsed || knownPayload is null)
         {
@@ -137,7 +162,7 @@ public static class ArchivedCardSnapshotSerialiser
         }
 
         var payload = knownPayload.Payload;
-        card = new CardDto(
+        var card = new CardDto(
             payload.OriginalCardId,
             payload.BoardColumnId,
             payload.CardTypeId,
@@ -152,6 +177,10 @@ public static class ArchivedCardSnapshotSerialiser
             payload.UpdatedAtUtc,
             payload.AssignedUserId,
             null);
+
+        snapshot = new ArchivedCardSnapshotCurrentDto(
+            card,
+            payload.Comments?.ToList() ?? []);
         return true;
     }
 }
@@ -177,10 +206,21 @@ public sealed record ArchivedCardSnapshotV1Payload(
     IReadOnlyList<string> TagNames,
     DateTime CreatedAtUtc,
     DateTime UpdatedAtUtc,
-    int? AssignedUserId = null);
+    int? AssignedUserId = null,
+    IReadOnlyList<ArchivedCardSnapshotCommentV1Payload>? Comments = null);
+
+public sealed record ArchivedCardSnapshotCommentV1Payload(
+    string Text,
+    DateTime CreatedAtUtc,
+    int? AuthorUserId = null,
+    string? AuthorEmail = null);
 
 public sealed record ArchivedCardSnapshotKnownPayload(
     string Schema,
     int Version,
     DateTime CapturedAtUtc,
     ArchivedCardSnapshotV1Payload Payload);
+
+public sealed record ArchivedCardSnapshotCurrentDto(
+    CardDto Card,
+    IReadOnlyList<ArchivedCardSnapshotCommentV1Payload> Comments);

--- a/BoardOil.Services/Card/CardArchiveService.cs
+++ b/BoardOil.Services/Card/CardArchiveService.cs
@@ -11,8 +11,10 @@ using BoardOil.Persistence.Abstractions.Column;
 using BoardOil.Persistence.Abstractions.Entities;
 using BoardOil.Persistence.Abstractions.Image;
 using BoardOil.Persistence.Abstractions.Tag;
+using BoardOil.Persistence.Abstractions.Users;
 using BoardOil.Services.Ordering;
 using BoardOil.Services.Tag;
+using BoardOil.Services.Users;
 using System.Text;
 using System.Text.Json;
 
@@ -20,10 +22,12 @@ namespace BoardOil.Services.Card;
 
 public sealed class CardArchiveService(
     ICardRepository cardRepository,
+    ICardCommentRepository cardCommentRepository,
     IArchivedCardRepository archivedCardRepository,
     ICardTypeRepository cardTypeRepository,
     IColumnRepository columnRepository,
     IBoardMemberRepository boardMemberRepository,
+    IUserRepository userRepository,
     IImageRepository imageRepository,
     ITagRepository tagRepository,
     IBoardAuthorisationService boardAuthorisationService,
@@ -33,6 +37,7 @@ public sealed class CardArchiveService(
     private const int MaxArchiveSnapshotJsonBytes = 524_288;
     private const int MaxCardTitleLength = 200;
     private const int MaxCardDescriptionLength = 20_000;
+    private const int MaxCommentLength = 4_000;
     private const int DefaultListLimit = 50;
     private const int MaxListLimit = 200;
 
@@ -135,11 +140,12 @@ public sealed class CardArchiveService(
             return ApiErrors.NotFound("Archived card not found.");
         }
 
-        var parsed = ArchivedCardSnapshotSerialiser.TryBuildCurrentCardDto(archivedCard.SnapshotJson, out var snapshotCard, out var snapshotReadError);
-        if (!parsed || snapshotCard is null)
+        var parsed = ArchivedCardSnapshotSerialiser.TryBuildCurrentSnapshot(archivedCard.SnapshotJson, out var snapshot, out var snapshotReadError);
+        if (!parsed || snapshot is null)
         {
             return ApiErrors.BadRequest($"Archived card snapshot cannot be restored. {snapshotReadError ?? "Snapshot is invalid."}");
         }
+        var snapshotCard = snapshot.Card;
 
         var targetColumn = await ResolveRestoreColumnAsync(boardId, snapshotCard.BoardColumnId);
         if (targetColumn is null)
@@ -155,6 +161,7 @@ public sealed class CardArchiveService(
         }
 
         var validationErrors = ValidateSnapshotCardData(snapshotCard);
+        validationErrors.AddRange(ValidateSnapshotComments(snapshot.Comments));
         if (validationErrors.Count > 0)
         {
             return ApiErrors.BadRequest("Archived card snapshot cannot be restored.", validationErrors);
@@ -186,6 +193,20 @@ public sealed class CardArchiveService(
             UpdatedAtUtc = snapshotCard.UpdatedAtUtc == default ? now : snapshotCard.UpdatedAtUtc
         };
         ReplaceTags(restoredCard, resolvedTags);
+        var commentAuthorByUserId = new Dictionary<int, EntityUser?>();
+        var commentAuthorByNormalisedEmail = new Dictionary<string, EntityUser?>(StringComparer.Ordinal);
+        foreach (var snapshotComment in snapshot.Comments)
+        {
+            var author = await ResolveCommentAuthorForRestoreAsync(snapshotComment, commentAuthorByUserId, commentAuthorByNormalisedEmail);
+            cardCommentRepository.Add(new EntityCardComment
+            {
+                Card = restoredCard,
+                AuthorUserId = author?.Id,
+                AuthorUser = author,
+                Text = snapshotComment.Text,
+                CreatedAtUtc = snapshotComment.CreatedAtUtc
+            });
+        }
 
         cardRepository.Add(restoredCard);
         archivedCardRepository.Remove(archivedCard);
@@ -399,6 +420,58 @@ public sealed class CardArchiveService(
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToList();
 
+    private async Task<EntityUser?> ResolveCommentAuthorForRestoreAsync(
+        ArchivedCardSnapshotCommentV1Payload snapshotComment,
+        IDictionary<int, EntityUser?> authorByUserId,
+        IDictionary<string, EntityUser?> authorByNormalisedEmail)
+    {
+        if (snapshotComment.AuthorUserId.HasValue)
+        {
+            var authorUserId = snapshotComment.AuthorUserId.Value;
+            if (authorByUserId.TryGetValue(authorUserId, out var cachedAuthor))
+            {
+                return cachedAuthor;
+            }
+
+            var user = userRepository.Get(authorUserId);
+            authorByUserId[authorUserId] = user;
+            if (user is not null && !string.IsNullOrWhiteSpace(user.NormalisedEmail))
+            {
+                authorByNormalisedEmail.TryAdd(user.NormalisedEmail, user);
+            }
+
+            if (user is not null)
+            {
+                return user;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(snapshotComment.AuthorEmail))
+        {
+            return null;
+        }
+
+        var normalisedEmail = EmailAddressRules.TryNormalise(snapshotComment.AuthorEmail);
+        if (string.IsNullOrWhiteSpace(normalisedEmail))
+        {
+            return null;
+        }
+
+        if (authorByNormalisedEmail.TryGetValue(normalisedEmail, out var cachedByEmail))
+        {
+            return cachedByEmail;
+        }
+
+        var emailUser = await userRepository.GetByNormalisedEmailAsync(normalisedEmail);
+        authorByNormalisedEmail[normalisedEmail] = emailUser;
+        if (emailUser is not null)
+        {
+            authorByUserId[emailUser.Id] = emailUser;
+        }
+
+        return emailUser;
+    }
+
     private static List<ValidationError> ValidateSnapshotCardData(CardDto snapshotCard)
     {
         var errors = new List<ValidationError>();
@@ -419,6 +492,36 @@ public sealed class CardArchiveService(
         if (snapshotCard.Description.Length > MaxCardDescriptionLength)
         {
             errors.Add(new ValidationError("snapshot.description", $"Card description must be {MaxCardDescriptionLength} characters or fewer."));
+        }
+
+        return errors;
+    }
+
+    private static IReadOnlyList<ValidationError> ValidateSnapshotComments(IReadOnlyList<ArchivedCardSnapshotCommentV1Payload> comments)
+    {
+        var errors = new List<ValidationError>();
+        for (var commentIndex = 0; commentIndex < comments.Count; commentIndex++)
+        {
+            var comment = comments[commentIndex];
+            var propertyPrefix = $"snapshot.comments[{commentIndex}]";
+            var text = comment.Text?.Trim() ?? string.Empty;
+            if (text.Length == 0)
+            {
+                errors.Add(new ValidationError($"{propertyPrefix}.text", "Comment text is required."));
+                continue;
+            }
+
+            if (text.Length > MaxCommentLength)
+            {
+                errors.Add(new ValidationError(
+                    $"{propertyPrefix}.text",
+                    $"Comment text must be {MaxCommentLength} characters or fewer."));
+            }
+
+            if (comment.CreatedAtUtc == default)
+            {
+                errors.Add(new ValidationError($"{propertyPrefix}.createdAtUtc", "Comment created time is required."));
+            }
         }
 
         return errors;

--- a/BoardOil.Services/Card/CardArchiveService.cs
+++ b/BoardOil.Services/Card/CardArchiveService.cs
@@ -34,7 +34,7 @@ public sealed class CardArchiveService(
     IBoardEvents boardEvents,
     IDbContextScopeFactory scopeFactory) : ICardArchiveService
 {
-    private const int MaxArchiveSnapshotJsonBytes = 524_288;
+    private const int MaxArchiveSnapshotJsonBytes = 2_097_152;
     private const int MaxCardTitleLength = 200;
     private const int MaxCardDescriptionLength = 20_000;
     private const int MaxCommentLength = 4_000;
@@ -270,7 +270,9 @@ public sealed class CardArchiveService(
         var snapshotJson = ArchivedCardSnapshotSerialiser.CreateSnapshotJson(boardId, card, archivedAtUtc);
         if (Encoding.UTF8.GetByteCount(snapshotJson) > MaxArchiveSnapshotJsonBytes)
         {
-            return new ArchivedCardBuildResult(null, ApiErrors.InternalError("Archive snapshot exceeds configured size limit."));
+            return new ArchivedCardBuildResult(
+                null,
+                ApiErrors.BadRequest("This card is too large to archive."));
         }
 
         var searchTitle = card.Title.Trim();

--- a/BoardOil.Services/Card/CardCommentService.cs
+++ b/BoardOil.Services/Card/CardCommentService.cs
@@ -1,0 +1,94 @@
+using BoardOil.Abstractions.Board;
+using BoardOil.Abstractions.Card;
+using BoardOil.Abstractions.DataAccess;
+using BoardOil.Contracts.Card;
+using BoardOil.Contracts.Contracts;
+using BoardOil.Persistence.Abstractions.Card;
+using BoardOil.Persistence.Abstractions.Entities;
+
+namespace BoardOil.Services.Card;
+
+public sealed class CardCommentService(
+    ICardRepository cardRepository,
+    ICardCommentRepository cardCommentRepository,
+    IBoardAuthorisationService boardAuthorisationService,
+    IDbContextScopeFactory scopeFactory) : ICardCommentService
+{
+    private const int MaxCommentLength = 4_000;
+    private readonly IDbContextScopeFactory _scopeFactory = scopeFactory;
+
+    public async Task<ApiResult<IReadOnlyList<CardCommentDto>>> GetCommentsAsync(int boardId, int cardId, int actorUserId)
+    {
+        using var scope = _scopeFactory.CreateReadOnly();
+
+        var hasPermission = await boardAuthorisationService.HasPermissionAsync(boardId, actorUserId, BoardPermission.BoardAccess);
+        if (!hasPermission)
+        {
+            return ApiErrors.Forbidden("You do not have access to this board.");
+        }
+
+        var card = await cardRepository.GetWithTagsAndBoardAsync(cardId);
+        if (card is null || card.BoardColumn.BoardId != boardId)
+        {
+            return ApiErrors.NotFound("Card not found.");
+        }
+
+        var comments = await cardCommentRepository.GetForCardOrderedAsync(cardId);
+        return comments
+            .Select(x => x.ToCardCommentDto())
+            .ToList();
+    }
+
+    public async Task<ApiResult<CardCommentDto>> CreateCommentAsync(int boardId, int cardId, CreateCardCommentRequest request, int actorUserId)
+    {
+        using var scope = _scopeFactory.Create();
+
+        var hasPermission = await boardAuthorisationService.HasPermissionAsync(boardId, actorUserId, BoardPermission.CardUpdate);
+        if (!hasPermission)
+        {
+            return ApiErrors.Forbidden("You do not have permission for this action.");
+        }
+
+        var card = await cardRepository.GetWithTagsAndBoardAsync(cardId);
+        if (card is null || card.BoardColumn.BoardId != boardId)
+        {
+            return ApiErrors.NotFound("Card not found.");
+        }
+
+        var validationErrors = ValidateCreateRequest(request);
+        if (validationErrors.Count > 0)
+        {
+            return ApiErrors.BadRequest("Validation failed.", validationErrors);
+        }
+
+        var comment = new EntityCardComment
+        {
+            CardId = cardId,
+            AuthorUserId = actorUserId,
+            Text = request.Text.Trim(),
+            CreatedAtUtc = DateTime.UtcNow
+        };
+        cardCommentRepository.Add(comment);
+        await scope.SaveChangesAsync();
+
+        return ApiResults.Created(comment.ToCardCommentDto());
+    }
+
+    private static IReadOnlyList<ValidationError> ValidateCreateRequest(CreateCardCommentRequest request)
+    {
+        var errors = new List<ValidationError>();
+        var text = request.Text?.Trim() ?? string.Empty;
+        if (text.Length == 0)
+        {
+            errors.Add(new ValidationError("text", "Comment text is required."));
+            return errors;
+        }
+
+        if (text.Length > MaxCommentLength)
+        {
+            errors.Add(new ValidationError("text", $"Comment text must be {MaxCommentLength} characters or fewer."));
+        }
+
+        return errors;
+    }
+}

--- a/BoardOil.Services/Card/CardCommentService.cs
+++ b/BoardOil.Services/Card/CardCommentService.cs
@@ -1,3 +1,4 @@
+using BoardOil.Abstractions;
 using BoardOil.Abstractions.Board;
 using BoardOil.Abstractions.Card;
 using BoardOil.Abstractions.DataAccess;
@@ -14,6 +15,7 @@ public sealed class CardCommentService(
     ICardCommentRepository cardCommentRepository,
     IImageRepository imageRepository,
     IBoardAuthorisationService boardAuthorisationService,
+    IBoardEvents boardEvents,
     IDbContextScopeFactory scopeFactory) : ICardCommentService
 {
     private const int MaxCommentLength = 4_000;
@@ -91,7 +93,9 @@ public sealed class CardCommentService(
             imageRelativePath = image?.RelativePath;
         }
 
-        return ApiResults.Created(savedComment.ToCardCommentDto(savedComment.AuthorUser?.DisplayName, imageRelativePath));
+        var createdComment = savedComment.ToCardCommentDto(savedComment.AuthorUser?.DisplayName, imageRelativePath);
+        await boardEvents.CommentCreatedAsync(boardId, createdComment);
+        return ApiResults.Created(createdComment);
     }
 
     private static IReadOnlyList<ValidationError> ValidateCreateRequest(CreateCardCommentRequest request)

--- a/BoardOil.Services/Card/CardCommentService.cs
+++ b/BoardOil.Services/Card/CardCommentService.cs
@@ -5,12 +5,14 @@ using BoardOil.Contracts.Card;
 using BoardOil.Contracts.Contracts;
 using BoardOil.Persistence.Abstractions.Card;
 using BoardOil.Persistence.Abstractions.Entities;
+using BoardOil.Persistence.Abstractions.Image;
 
 namespace BoardOil.Services.Card;
 
 public sealed class CardCommentService(
     ICardRepository cardRepository,
     ICardCommentRepository cardCommentRepository,
+    IImageRepository imageRepository,
     IBoardAuthorisationService boardAuthorisationService,
     IDbContextScopeFactory scopeFactory) : ICardCommentService
 {
@@ -34,8 +36,9 @@ public sealed class CardCommentService(
         }
 
         var comments = await cardCommentRepository.GetForCardOrderedAsync(cardId);
+        var imageByAuthorUserId = await LoadAuthorImageLookupAsync(comments);
         return comments
-            .Select(x => x.ToCardCommentDto())
+            .Select(x => x.ToCardCommentDto(imageByAuthorUserId.GetValueOrDefault(x.AuthorUserId)))
             .ToList();
     }
 
@@ -71,7 +74,14 @@ public sealed class CardCommentService(
         cardCommentRepository.Add(comment);
         await scope.SaveChangesAsync();
 
-        return ApiResults.Created(comment.ToCardCommentDto());
+        var savedComment = await cardCommentRepository.GetByIdWithAuthorAsync(comment.Id);
+        if (savedComment is null)
+        {
+            return ApiErrors.InternalError("Created comment could not be reloaded.");
+        }
+
+        var image = await imageRepository.GetLatestForEntityAsync(ImageEntityType.UserProfile, savedComment.AuthorUserId);
+        return ApiResults.Created(savedComment.ToCardCommentDto(image?.RelativePath));
     }
 
     private static IReadOnlyList<ValidationError> ValidateCreateRequest(CreateCardCommentRequest request)
@@ -90,5 +100,20 @@ public sealed class CardCommentService(
         }
 
         return errors;
+    }
+
+    private async Task<IReadOnlyDictionary<int, string>> LoadAuthorImageLookupAsync(IReadOnlyList<EntityCardComment> comments)
+    {
+        var authorUserIds = comments
+            .Select(x => x.AuthorUserId)
+            .Distinct()
+            .ToArray();
+        if (authorUserIds.Length == 0)
+        {
+            return new Dictionary<int, string>();
+        }
+
+        var images = await imageRepository.GetLatestForEntitiesAsync(ImageEntityType.UserProfile, authorUserIds);
+        return images.ToDictionary(x => x.EntityId, x => x.RelativePath);
     }
 }

--- a/BoardOil.Services/Card/CardCommentService.cs
+++ b/BoardOil.Services/Card/CardCommentService.cs
@@ -17,6 +17,7 @@ public sealed class CardCommentService(
     IDbContextScopeFactory scopeFactory) : ICardCommentService
 {
     private const int MaxCommentLength = 4_000;
+    private const string UnknownCommentAuthorDisplayName = "Unknown user";
     private readonly IDbContextScopeFactory _scopeFactory = scopeFactory;
 
     public async Task<ApiResult<IReadOnlyList<CardCommentDto>>> GetCommentsAsync(int boardId, int cardId, int actorUserId)
@@ -37,8 +38,11 @@ public sealed class CardCommentService(
 
         var comments = await cardCommentRepository.GetForCardOrderedAsync(cardId);
         var imageByAuthorUserId = await LoadAuthorImageLookupAsync(comments);
+        var displayNameByAuthorUserId = LoadAuthorDisplayNameLookup(comments);
         return comments
-            .Select(x => x.ToCardCommentDto(imageByAuthorUserId.GetValueOrDefault(x.AuthorUserId)))
+            .Select(x => x.ToCardCommentDto(
+                ResolveAuthorDisplayName(x, displayNameByAuthorUserId),
+                ResolveAuthorImageRelativePath(x, imageByAuthorUserId)))
             .ToList();
     }
 
@@ -80,8 +84,14 @@ public sealed class CardCommentService(
             return ApiErrors.InternalError("Created comment could not be reloaded.");
         }
 
-        var image = await imageRepository.GetLatestForEntityAsync(ImageEntityType.UserProfile, savedComment.AuthorUserId);
-        return ApiResults.Created(savedComment.ToCardCommentDto(image?.RelativePath));
+        string? imageRelativePath = null;
+        if (savedComment.AuthorUserId.HasValue)
+        {
+            var image = await imageRepository.GetLatestForEntityAsync(ImageEntityType.UserProfile, savedComment.AuthorUserId.Value);
+            imageRelativePath = image?.RelativePath;
+        }
+
+        return ApiResults.Created(savedComment.ToCardCommentDto(savedComment.AuthorUser?.DisplayName, imageRelativePath));
     }
 
     private static IReadOnlyList<ValidationError> ValidateCreateRequest(CreateCardCommentRequest request)
@@ -102,10 +112,43 @@ public sealed class CardCommentService(
         return errors;
     }
 
+    private static IReadOnlyDictionary<int, string> LoadAuthorDisplayNameLookup(IReadOnlyList<EntityCardComment> comments) =>
+        comments
+            .Where(x => x.AuthorUserId.HasValue && x.AuthorUser is not null)
+            .GroupBy(x => x.AuthorUserId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(x => x.AuthorUser!.DisplayName).First());
+
+    private static string ResolveAuthorDisplayName(
+        EntityCardComment comment,
+        IReadOnlyDictionary<int, string> displayNameByAuthorUserId)
+    {
+        if (!comment.AuthorUserId.HasValue)
+        {
+            return UnknownCommentAuthorDisplayName;
+        }
+
+        return displayNameByAuthorUserId.GetValueOrDefault(comment.AuthorUserId.Value, UnknownCommentAuthorDisplayName);
+    }
+
+    private static string? ResolveAuthorImageRelativePath(
+        EntityCardComment comment,
+        IReadOnlyDictionary<int, string> imageByAuthorUserId)
+    {
+        if (!comment.AuthorUserId.HasValue)
+        {
+            return null;
+        }
+
+        return imageByAuthorUserId.GetValueOrDefault(comment.AuthorUserId.Value);
+    }
+
     private async Task<IReadOnlyDictionary<int, string>> LoadAuthorImageLookupAsync(IReadOnlyList<EntityCardComment> comments)
     {
         var authorUserIds = comments
-            .Select(x => x.AuthorUserId)
+            .Where(x => x.AuthorUserId.HasValue)
+            .Select(x => x.AuthorUserId!.Value)
             .Distinct()
             .ToArray();
         if (authorUserIds.Length == 0)

--- a/BoardOil.Services/Card/CardMappingExtensions.cs
+++ b/BoardOil.Services/Card/CardMappingExtensions.cs
@@ -6,6 +6,8 @@ namespace BoardOil.Services.Card;
 
 public static class CardMappingExtensions
 {
+    private const string UnknownCommentAuthorDisplayName = "Unknown user";
+
     public static CardDto ToCardDto(this EntityBoardCard card) =>
         new(
             card.Id,
@@ -72,14 +74,17 @@ public static class CardMappingExtensions
             tag.StylePropertiesJson,
             tag.Emoji);
 
-    public static CardCommentDto ToCardCommentDto(this EntityCardComment comment, string? authorImageRelativePath = null) =>
+    public static CardCommentDto ToCardCommentDto(
+        this EntityCardComment comment,
+        string? authorDisplayName = null,
+        string? authorImageRelativePath = null) =>
         new(
             comment.Id,
             comment.CardId,
             comment.AuthorUserId,
             comment.Text,
             comment.CreatedAtUtc,
-            comment.AuthorUser.DisplayName,
+            authorDisplayName ?? comment.AuthorUser?.DisplayName ?? UnknownCommentAuthorDisplayName,
             authorImageRelativePath);
 
     private static IReadOnlyList<string> ParseSearchTagsJson(string searchTagsJson)

--- a/BoardOil.Services/Card/CardMappingExtensions.cs
+++ b/BoardOil.Services/Card/CardMappingExtensions.cs
@@ -72,6 +72,14 @@ public static class CardMappingExtensions
             tag.StylePropertiesJson,
             tag.Emoji);
 
+    public static CardCommentDto ToCardCommentDto(this EntityCardComment comment) =>
+        new(
+            comment.Id,
+            comment.CardId,
+            comment.AuthorUserId,
+            comment.Text,
+            comment.CreatedAtUtc);
+
     private static IReadOnlyList<string> ParseSearchTagsJson(string searchTagsJson)
     {
         if (string.IsNullOrWhiteSpace(searchTagsJson))

--- a/BoardOil.Services/Card/CardMappingExtensions.cs
+++ b/BoardOil.Services/Card/CardMappingExtensions.cs
@@ -72,13 +72,15 @@ public static class CardMappingExtensions
             tag.StylePropertiesJson,
             tag.Emoji);
 
-    public static CardCommentDto ToCardCommentDto(this EntityCardComment comment) =>
+    public static CardCommentDto ToCardCommentDto(this EntityCardComment comment, string? authorImageRelativePath = null) =>
         new(
             comment.Id,
             comment.CardId,
             comment.AuthorUserId,
             comment.Text,
-            comment.CreatedAtUtc);
+            comment.CreatedAtUtc,
+            comment.AuthorUser.DisplayName,
+            authorImageRelativePath);
 
     private static IReadOnlyList<string> ParseSearchTagsJson(string searchTagsJson)
     {

--- a/BoardOil.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/BoardOil.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAppSettingRepository, AppSettingRepository>();
         services.AddScoped<IColumnRepository, ColumnRepository>();
         services.AddScoped<ICardRepository, CardRepository>();
+        services.AddScoped<ICardCommentRepository, CardCommentRepository>();
         services.AddScoped<IArchivedCardRepository, ArchivedCardRepository>();
         services.AddScoped<ICardTypeRepository, CardTypeRepository>();
         services.AddScoped<ITagRepository, TagRepository>();
@@ -69,6 +70,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IBoardMemberService, BoardMemberService>();
         services.AddScoped<IColumnService, ColumnService>();
         services.AddScoped<ICardService, CardService>();
+        services.AddScoped<ICardCommentService, CardCommentService>();
         services.AddScoped<ICardArchiveService, CardArchiveService>();
         services.AddScoped<ICardTypeService, CardTypeService>();
         services.AddScoped<ITagService, TagService>();

--- a/BoardOil.Web/src/board/components/CardEditorDialog.vue
+++ b/BoardOil.Web/src/board/components/CardEditorDialog.vue
@@ -52,7 +52,7 @@
                 <button
                   type="button"
                   class="btn card-editor-comment-add-button"
-                  :disabled="newCommentText.trim().length === 0"
+                  :disabled="newCommentText.trim().length === 0 || commentsBusy"
                   @click="addComment"
                 >
                   Add
@@ -259,6 +259,7 @@ const tagStore = useTagStore();
 const { board } = storeToRefs(boardStore);
 const { members: boardMembers, activeBoardId: boardMembersActiveBoardId } = storeToRefs(boardMembersStore);
 const { cardTypes, systemCardType } = storeToRefs(cardTypeStore);
+const { busy: commentsBusy } = storeToRefs(commentStore);
 const { saveCard: saveCardAction, deleteCard, archiveCard } = cardStore;
 const { loadCardComments, addCardComment: addCardCommentAction } = commentStore;
 const { loadMembers } = boardMembersStore;
@@ -519,7 +520,7 @@ async function ensureTagsExistForBoard(tagNames: string[]) {
 }
 
 async function addComment() {
-  if (!cardDraft.value) {
+  if (!cardDraft.value || commentsBusy.value) {
     return;
   }
 
@@ -575,7 +576,12 @@ async function archiveEditingCard() {
 
 watch(
   [routeBoardId, routeCardId, editingCard, board],
-  async ([nextBoardId, nextCardId, nextCard, nextBoard]) => {
+  async ([nextBoardId, nextCardId, nextCard, nextBoard], _previous, onCleanup) => {
+    let cancelled = false;
+    onCleanup(() => {
+      cancelled = true;
+    });
+
     if (nextBoardId === null) {
       clearDraft();
       void router.replace({ name: 'boards' });
@@ -594,9 +600,15 @@ watch(
 
     if (cardTypes.value.length === 0) {
       await loadCardTypes(nextBoardId);
+      if (cancelled) {
+        return;
+      }
     }
     if (boardMembersActiveBoardId.value !== nextBoardId || boardMembers.value.length === 0) {
       await loadMembers(nextBoardId);
+      if (cancelled) {
+        return;
+      }
     }
 
     if (!nextCard) {
@@ -606,6 +618,9 @@ watch(
     }
 
     await loadCardComments(nextBoardId, nextCard.id);
+    if (cancelled) {
+      return;
+    }
 
     if (cardDraft.value?.id !== nextCard.id) {
       const refreshedCard = cardStore.getCardById(nextCard.id) ?? nextCard;

--- a/BoardOil.Web/src/board/components/CardEditorDialog.vue
+++ b/BoardOil.Web/src/board/components/CardEditorDialog.vue
@@ -22,6 +22,39 @@
               min-height="12rem"
             />
           </div>
+          <section class="card-editor-comments-section" aria-label="Card comments">
+            <div class="card-editor-comment-entry">
+              <h3 class="card-editor-comments-title">Comments</h3>
+              <textarea
+                v-model="newCommentText"
+                class="card-editor-comment-input"
+                rows="3"
+                maxlength="4000"
+                placeholder="Add a comment"
+              />
+              <button
+                type="button"
+                class="btn"
+                :disabled="newCommentText.trim().length === 0"
+                @click="addComment"
+              >
+                Add comment
+              </button>
+            </div>
+
+            <div class="card-editor-comments-list">
+              <p v-if="cardComments.length === 0" class="card-editor-comments-empty">
+                No comments yet.
+              </p>
+              <article
+                v-for="comment in cardComments"
+                :key="comment.id"
+                class="card-editor-comment"
+              >
+                <p class="card-editor-comment-text">{{ comment.text }}</p>
+              </article>
+            </div>
+          </section>
         </div>
 
         <aside class="card-editor-options" aria-label="Card options">
@@ -171,6 +204,7 @@ import { useBoardStore } from '../stores/boardStore';
 import { useBoardMembersStore } from '../stores/boardMembersStore';
 import { useCardStore } from '../stores/cardStore';
 import { useCardTypeStore } from '../stores/cardTypeStore';
+import { useCommentStore } from '../stores/commentStore';
 import { useTagStore } from '../stores/tagStore';
 import { resolveDraftCardTypeId, resolveSelectedCardTypeEmoji } from './cardTypeSelection';
 
@@ -180,15 +214,18 @@ const boardStore = useBoardStore();
 const boardMembersStore = useBoardMembersStore();
 const cardStore = useCardStore();
 const cardTypeStore = useCardTypeStore();
+const commentStore = useCommentStore();
 const tagStore = useTagStore();
 const { board } = storeToRefs(boardStore);
 const { members: boardMembers, activeBoardId: boardMembersActiveBoardId } = storeToRefs(boardMembersStore);
 const { cardTypes, systemCardType } = storeToRefs(cardTypeStore);
 const { saveCard: saveCardAction, deleteCard, archiveCard } = cardStore;
+const { loadCardComments, addCardComment: addCardCommentAction } = commentStore;
 const { loadMembers } = boardMembersStore;
 const { loadCardTypes } = cardTypeStore;
 const { ensureTagsExist } = tagStore;
 const maxDescriptionLength = 20_000;
+const maxCommentLength = 4_000;
 type CardDraft = {
   id: number;
   title: string;
@@ -201,6 +238,7 @@ type CardDraft = {
 };
 
 const cardDraft = ref<CardDraft | null>(null);
+const newCommentText = ref('');
 
 const routeCardId = computed<number | null>(() => {
   const raw = route.params.cardId;
@@ -215,6 +253,7 @@ const routeBoardId = computed<number | null>(() => {
 });
 
 const editingCard = computed(() => cardStore.getCardById(routeCardId.value));
+const cardComments = computed(() => commentStore.getCommentsForCard(cardDraft.value?.id ?? null));
 const boardColumns = computed(() => board.value?.columns ?? []);
 const selectedBoardColumnLabel = computed(() => {
   if (!cardDraft.value) {
@@ -276,6 +315,7 @@ function normaliseDescription(value: string) {
 
 function clearDraft() {
   cardDraft.value = null;
+  newCommentText.value = '';
 }
 
 async function closeCardEditor() {
@@ -361,6 +401,29 @@ async function ensureTagsExistForBoard(tagNames: string[]) {
   return ensureTagsExist(tagNames, routeBoardId.value);
 }
 
+async function addComment() {
+  if (!cardDraft.value) {
+    return;
+  }
+
+  const text = newCommentText.value.trim().slice(0, maxCommentLength);
+  if (text.length === 0) {
+    return;
+  }
+
+  const boardId = routeBoardId.value;
+  if (boardId === null) {
+    return;
+  }
+
+  const result = await addCardCommentAction(boardId, cardDraft.value.id, text);
+  if (!result?.ok) {
+    return;
+  }
+
+  newCommentText.value = '';
+}
+
 async function deleteEditingCard() {
   if (!cardDraft.value) {
     return;
@@ -425,16 +488,19 @@ watch(
       return;
     }
 
+    await loadCardComments(nextBoardId, nextCard.id);
+
     if (cardDraft.value?.id !== nextCard.id) {
+      const refreshedCard = cardStore.getCardById(nextCard.id) ?? nextCard;
       cardDraft.value = {
-        id: nextCard.id,
-        title: nextCard.title,
-        description: normaliseDescription(nextCard.description),
-        tagNames: [...nextCard.tagNames],
-        cardTypeId: nextCard.cardTypeId,
-        boardColumnId: nextCard.boardColumnId,
-        assignedUserId: nextCard.assignedUserId ?? null,
-        assignedUserName: nextCard.assignedUserName ?? null
+        id: refreshedCard.id,
+        title: refreshedCard.title,
+        description: normaliseDescription(refreshedCard.description),
+        tagNames: [...refreshedCard.tagNames],
+        cardTypeId: refreshedCard.cardTypeId,
+        boardColumnId: refreshedCard.boardColumnId,
+        assignedUserId: refreshedCard.assignedUserId ?? null,
+        assignedUserName: refreshedCard.assignedUserName ?? null
       };
       return;
     }
@@ -499,7 +565,7 @@ watch(
 .card-editor-layout {
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(14rem, 1fr);
-  gap: 0.85rem;
+  gap: 0;
   flex: 1;
   min-height: 0;
   overflow: hidden;
@@ -511,7 +577,58 @@ watch(
   gap: 0.5rem;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.75rem;
+  margin-right: 0.25rem;
+}
+
+.card-editor-comments-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-top: 1px solid var(--bo-border-soft);
+  padding-top: 0.5rem;
+}
+
+.card-editor-comments-title {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.card-editor-comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.card-editor-comments-empty {
+  margin: 0;
+  color: var(--bo-muted-text);
+  font-size: 0.9rem;
+}
+
+.card-editor-comment {
+  border: 1px solid var(--bo-border-soft);
+  border-radius: 0.4rem;
+  padding: 0.5rem 0.6rem;
+  background: color-mix(in srgb, var(--bo-bg) 92%, var(--bo-muted-bg) 8%);
+}
+
+.card-editor-comment-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.card-editor-comment-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.card-editor-comment-input {
+  width: 100%;
+  resize: vertical;
 }
 
 .card-editor-select-field {
@@ -575,9 +692,31 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  flex: 1 1 0;
-  min-height: 0;
-  overflow: hidden;
+  flex: 0 0 auto;
+  min-height: fit-content;
+  overflow: visible;
+  width: 100%;
+}
+
+.card-editor-description-field :deep(.md-editor),
+.card-editor-description-field :deep(.md-editor-input),
+.card-editor-description-field :deep(.md-editor-content) {
+  flex: 0 0 auto;
+  min-height: fit-content;
+  overflow: visible;
+  width: 100%;
+}
+
+.card-editor-description-field :deep(.md-editor-content .tiptap) {
+  height: auto;
+  max-height: none;
+  overflow-y: visible;
+  width: 100%;
+}
+
+.card-editor-description-field :deep(.md-editor-textarea) {
+  max-height: none;
+  overflow-y: hidden;
 }
 
 .card-editor-field-label {

--- a/BoardOil.Web/src/board/components/CardEditorDialog.vue
+++ b/BoardOil.Web/src/board/components/CardEditorDialog.vue
@@ -73,11 +73,11 @@
                   <span class="card-editor-comment-author">
                     <UserAvatar
                       :image-relative-path="comment.authorImageRelativePath ?? null"
-                      :display-name="comment.authorDisplayName ?? `User #${comment.authorUserId}`"
+                      :display-name="comment.authorDisplayName ?? 'Unknown user'"
                       size="sm"
                       class="card-editor-comment-author-avatar"
                     />
-                    <span class="card-editor-comment-author-name">{{ comment.authorDisplayName ?? `User #${comment.authorUserId}` }}</span>
+                    <span class="card-editor-comment-author-name">{{ comment.authorDisplayName ?? 'Unknown user' }}</span>
                   </span>
                   <time class="card-editor-comment-timestamp" :datetime="comment.createdAtUtc">{{ formatCommentDateTime(comment.createdAtUtc) }}</time>
                 </header>

--- a/BoardOil.Web/src/board/components/CardEditorDialog.vue
+++ b/BoardOil.Web/src/board/components/CardEditorDialog.vue
@@ -14,32 +14,50 @@
     <template v-if="cardDraft">
       <div class="card-editor-layout">
         <div class="card-editor-main">
+          <MdEditorToolbar
+            class="card-editor-shared-toolbar"
+            :state="activeToolbarState"
+            :is-plain-text-mode="activeIsPlainTextMode"
+            @action="runSharedToolbarAction"
+            @toggle-plain-text-mode="toggleSharedToolbarPlainTextMode"
+          />
           <div class="card-editor-description-field">
             <MdEditor
+              ref="descriptionEditorRef"
               v-model="descriptionDraft"
               aria-label="Card description"
               :max-length="maxDescriptionLength"
               min-height="12rem"
+              :show-toolbar="false"
+              @focus="setActiveEditor('description')"
+              @toolbar-state-change="updateToolbarState('description', $event)"
+              @plain-text-mode-change="updatePlainTextMode('description', $event)"
             />
           </div>
           <section class="card-editor-comments-section" aria-label="Card comments">
             <div class="card-editor-comment-entry">
               <h3 class="card-editor-comments-title">Comments</h3>
-              <textarea
-                v-model="newCommentText"
-                class="card-editor-comment-input"
-                rows="3"
-                maxlength="4000"
-                placeholder="Add a comment"
-              />
-              <button
-                type="button"
-                class="btn"
-                :disabled="newCommentText.trim().length === 0"
-                @click="addComment"
-              >
-                Add comment
-              </button>
+              <div class="card-editor-comment-entry-row">
+                <MdEditor
+                  ref="commentEditorRef"
+                  v-model="newCommentText"
+                  aria-label="Comment"
+                  :max-length="maxCommentLength"
+                  min-height="6rem"
+                  :show-toolbar="false"
+                  @focus="setActiveEditor('comment')"
+                  @toolbar-state-change="updateToolbarState('comment', $event)"
+                  @plain-text-mode-change="updatePlainTextMode('comment', $event)"
+                />
+                <button
+                  type="button"
+                  class="btn card-editor-comment-add-button"
+                  :disabled="newCommentText.trim().length === 0"
+                  @click="addComment"
+                >
+                  Add
+                </button>
+              </div>
             </div>
 
             <div class="card-editor-comments-list">
@@ -63,7 +81,13 @@
                   </span>
                   <time class="card-editor-comment-timestamp" :datetime="comment.createdAtUtc">{{ formatCommentDateTime(comment.createdAtUtc) }}</time>
                 </header>
-                <p class="card-editor-comment-text">{{ comment.text }}</p>
+                <MdViewer
+                  class="card-editor-comment-body"
+                  :model-value="comment.text"
+                  aria-label="Comment content"
+                  :max-length="maxCommentLength"
+                  min-height="1.5rem"
+                />
               </article>
             </div>
           </section>
@@ -207,6 +231,8 @@ import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import MdEditor from '../../shared/components/MdEditor.vue';
+import MdEditorToolbar from '../../shared/components/MdEditorToolbar.vue';
+import MdViewer from '../../shared/components/MdViewer.vue';
 import BoDropdown from '../../shared/components/BoDropdown.vue';
 import UserAvatar from '../../shared/components/UserAvatar.vue';
 import CardTagEditor from './CardTagEditor.vue';
@@ -219,6 +245,8 @@ import { useCardTypeStore } from '../stores/cardTypeStore';
 import { useCommentStore } from '../stores/commentStore';
 import { useTagStore } from '../stores/tagStore';
 import { resolveDraftCardTypeId, resolveSelectedCardTypeEmoji } from './cardTypeSelection';
+import { mdEditorToolbarActions, type MdEditorToolbarActionEvent, type MdEditorToolbarActionId, type MdEditorToolbarActionState } from '../../shared/components/mdEditorToolbarActions';
+import { createDisabledToolbarState, resolveActiveIsPlainTextMode, resolveActiveToolbarState } from './cardEditorSharedToolbar';
 
 const route = useRoute();
 const router = useRouter();
@@ -251,6 +279,13 @@ type CardDraft = {
 
 const cardDraft = ref<CardDraft | null>(null);
 const newCommentText = ref('');
+const descriptionEditorRef = ref<InstanceType<typeof MdEditor> | null>(null);
+const commentEditorRef = ref<InstanceType<typeof MdEditor> | null>(null);
+const activeEditor = ref<'description' | 'comment'>('description');
+const descriptionToolbarState = ref<Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>>({});
+const commentToolbarState = ref<Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>>({});
+const descriptionIsPlainTextMode = ref(false);
+const commentIsPlainTextMode = ref(false);
 
 const routeCardId = computed<number | null>(() => {
   const raw = route.params.cardId;
@@ -320,6 +355,63 @@ const descriptionDraft = computed({
   },
   set: value => updateEditingCardDraft('description', value)
 });
+const disabledToolbarState = computed<Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>>(() => {
+  return createDisabledToolbarState(mdEditorToolbarActions.map(action => action.id));
+});
+const activeToolbarState = computed(() => {
+  return resolveActiveToolbarState(
+    activeEditor.value,
+    descriptionToolbarState.value,
+    commentToolbarState.value,
+    disabledToolbarState.value
+  );
+});
+const activeIsPlainTextMode = computed(() => {
+  return resolveActiveIsPlainTextMode(
+    activeEditor.value,
+    descriptionIsPlainTextMode.value,
+    commentIsPlainTextMode.value
+  );
+});
+
+function setActiveEditor(editor: 'description' | 'comment') {
+  activeEditor.value = editor;
+}
+
+function updateToolbarState(
+  editor: 'description' | 'comment',
+  state: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>
+) {
+  if (editor === 'comment') {
+    commentToolbarState.value = state;
+    return;
+  }
+
+  descriptionToolbarState.value = state;
+}
+
+function updatePlainTextMode(editor: 'description' | 'comment', isPlainTextMode: boolean) {
+  if (editor === 'comment') {
+    commentIsPlainTextMode.value = isPlainTextMode;
+    return;
+  }
+
+  descriptionIsPlainTextMode.value = isPlainTextMode;
+}
+
+function runSharedToolbarAction(actionEvent: MdEditorToolbarActionEvent) {
+  const editor = activeEditor.value === 'comment'
+    ? commentEditorRef.value
+    : descriptionEditorRef.value;
+  editor?.runToolbarAction(actionEvent);
+}
+
+function toggleSharedToolbarPlainTextMode() {
+  const editor = activeEditor.value === 'comment'
+    ? commentEditorRef.value
+    : descriptionEditorRef.value;
+  editor?.togglePlainTextMode();
+}
 
 function normaliseDescription(value: string) {
   return value.slice(0, maxDescriptionLength);
@@ -340,6 +432,7 @@ function formatCommentDateTime(value: string) {
 function clearDraft() {
   cardDraft.value = null;
   newCommentText.value = '';
+  activeEditor.value = 'description';
 }
 
 async function closeCardEditor() {
@@ -607,12 +700,21 @@ watch(
   margin-right: 0.25rem;
 }
 
+.card-editor-shared-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 0.2rem 0 0.35rem;
+  background: var(--bo-surface-base);
+}
+
 .card-editor-comments-section {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   border-top: 1px solid var(--bo-border-soft);
   padding-top: 0.5rem;
+  width: 100%;
 }
 
 .card-editor-comments-title {
@@ -624,6 +726,7 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  width: 100%;
 }
 
 .card-editor-comments-empty {
@@ -637,6 +740,8 @@ watch(
   border-radius: 0.4rem;
   padding: 0.5rem 0.6rem;
   background: color-mix(in srgb, var(--bo-bg) 92%, var(--bo-muted-bg) 8%);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .card-editor-comment-header {
@@ -669,20 +774,66 @@ watch(
   white-space: nowrap;
 }
 
-.card-editor-comment-text {
-  margin: 0;
-  white-space: pre-wrap;
-}
-
 .card-editor-comment-entry {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  width: 100%;
 }
 
-.card-editor-comment-input {
+.card-editor-comment-entry-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.card-editor-comment-add-button {
+  align-self: end;
+}
+
+.card-editor-comment-entry :deep(.md-editor) {
+  flex: 0 0 auto;
+  min-height: fit-content;
   width: 100%;
-  resize: vertical;
+}
+
+.card-editor-comment-entry :deep(.md-editor-input),
+.card-editor-comment-entry :deep(.md-editor-content) {
+  flex: 0 0 auto;
+  min-height: fit-content;
+  overflow: visible;
+  width: 100%;
+}
+
+.card-editor-comment-entry :deep(.md-editor-content .tiptap),
+.card-editor-comment-entry :deep(.md-editor-textarea) {
+  height: auto;
+  max-height: none;
+  overflow-y: visible;
+  width: 100%;
+}
+
+.card-editor-comment-body :deep(.md-viewer) {
+  flex: 0 0 auto;
+  min-height: fit-content;
+  overflow: visible;
+}
+
+.card-editor-comment-body :deep(.md-viewer-content) {
+  overflow: visible;
+}
+
+.card-editor-comment-body :deep(.md-viewer-content .tiptap) {
+  height: auto;
+  max-height: none;
+  min-height: 1.5rem;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  overflow-y: visible;
 }
 
 .card-editor-select-field {

--- a/BoardOil.Web/src/board/components/CardEditorDialog.vue
+++ b/BoardOil.Web/src/board/components/CardEditorDialog.vue
@@ -51,6 +51,18 @@
                 :key="comment.id"
                 class="card-editor-comment"
               >
+                <header class="card-editor-comment-header">
+                  <span class="card-editor-comment-author">
+                    <UserAvatar
+                      :image-relative-path="comment.authorImageRelativePath ?? null"
+                      :display-name="comment.authorDisplayName ?? `User #${comment.authorUserId}`"
+                      size="sm"
+                      class="card-editor-comment-author-avatar"
+                    />
+                    <span class="card-editor-comment-author-name">{{ comment.authorDisplayName ?? `User #${comment.authorUserId}` }}</span>
+                  </span>
+                  <time class="card-editor-comment-timestamp" :datetime="comment.createdAtUtc">{{ formatCommentDateTime(comment.createdAtUtc) }}</time>
+                </header>
                 <p class="card-editor-comment-text">{{ comment.text }}</p>
               </article>
             </div>
@@ -311,6 +323,18 @@ const descriptionDraft = computed({
 
 function normaliseDescription(value: string) {
   return value.slice(0, maxDescriptionLength);
+}
+
+function formatCommentDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
 }
 
 function clearDraft() {
@@ -613,6 +637,36 @@ watch(
   border-radius: 0.4rem;
   padding: 0.5rem 0.6rem;
   background: color-mix(in srgb, var(--bo-bg) 92%, var(--bo-muted-bg) 8%);
+}
+
+.card-editor-comment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.card-editor-comment-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.card-editor-comment-author-avatar {
+  flex-shrink: 0;
+}
+
+.card-editor-comment-author-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.card-editor-comment-timestamp {
+  font-size: 0.8rem;
+  color: var(--bo-muted-text);
+  white-space: nowrap;
 }
 
 .card-editor-comment-text {

--- a/BoardOil.Web/src/board/components/cardEditorSharedToolbar.test.ts
+++ b/BoardOil.Web/src/board/components/cardEditorSharedToolbar.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { createDisabledToolbarState, resolveActiveIsPlainTextMode, resolveActiveToolbarState } from './cardEditorSharedToolbar';
+import type { MdEditorToolbarActionId, MdEditorToolbarActionState } from '../../shared/components/mdEditorToolbarActions';
+
+describe('cardEditorSharedToolbar', () => {
+  it('creates disabled default state for each toolbar action', () => {
+    const actionIds: MdEditorToolbarActionId[] = ['bold', 'heading', 'link'];
+    const state = createDisabledToolbarState(actionIds);
+
+    expect(state.bold).toEqual({ disabled: true, isActive: false });
+    expect(state.heading).toEqual({ disabled: true, isActive: false });
+    expect(state.link).toEqual({ disabled: true, isActive: false });
+  });
+
+  it('routes active toolbar state to description by default', () => {
+    const descriptionState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {
+      bold: { disabled: false, isActive: true }
+    };
+    const commentState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {
+      italic: { disabled: false, isActive: true }
+    };
+    const fallback = createDisabledToolbarState(['bold', 'italic']);
+
+    expect(resolveActiveToolbarState('description', descriptionState, commentState, fallback)).toBe(descriptionState);
+  });
+
+  it('routes active toolbar state to comment when comment editor is active', () => {
+    const descriptionState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {
+      bold: { disabled: false, isActive: true }
+    };
+    const commentState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {
+      italic: { disabled: false, isActive: true }
+    };
+    const fallback = createDisabledToolbarState(['bold', 'italic']);
+
+    expect(resolveActiveToolbarState('comment', descriptionState, commentState, fallback)).toBe(commentState);
+  });
+
+  it('falls back to disabled state when active editor state is empty', () => {
+    const descriptionState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {};
+    const commentState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {};
+    const fallback = createDisabledToolbarState(['bold']);
+
+    expect(resolveActiveToolbarState('description', descriptionState, commentState, fallback)).toBe(fallback);
+    expect(resolveActiveToolbarState('comment', descriptionState, commentState, fallback)).toBe(fallback);
+  });
+
+  it('routes plain text mode based on active editor', () => {
+    expect(resolveActiveIsPlainTextMode('description', true, false)).toBe(true);
+    expect(resolveActiveIsPlainTextMode('description', false, true)).toBe(false);
+    expect(resolveActiveIsPlainTextMode('comment', true, false)).toBe(false);
+    expect(resolveActiveIsPlainTextMode('comment', false, true)).toBe(true);
+  });
+});

--- a/BoardOil.Web/src/board/components/cardEditorSharedToolbar.ts
+++ b/BoardOil.Web/src/board/components/cardEditorSharedToolbar.ts
@@ -1,0 +1,36 @@
+import type { MdEditorToolbarActionId, MdEditorToolbarActionState } from '../../shared/components/mdEditorToolbarActions';
+
+export type CardEditorActiveEditor = 'description' | 'comment';
+
+export function createDisabledToolbarState(actionIds: MdEditorToolbarActionId[]) {
+  const state: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>> = {};
+  for (const actionId of actionIds) {
+    state[actionId] = {
+      disabled: true,
+      isActive: false
+    };
+  }
+
+  return state;
+}
+
+export function resolveActiveToolbarState(
+  activeEditor: CardEditorActiveEditor,
+  descriptionToolbarState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>,
+  commentToolbarState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>,
+  disabledToolbarState: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>
+) {
+  if (activeEditor === 'comment') {
+    return Object.keys(commentToolbarState).length > 0 ? commentToolbarState : disabledToolbarState;
+  }
+
+  return Object.keys(descriptionToolbarState).length > 0 ? descriptionToolbarState : disabledToolbarState;
+}
+
+export function resolveActiveIsPlainTextMode(
+  activeEditor: CardEditorActiveEditor,
+  descriptionIsPlainTextMode: boolean,
+  commentIsPlainTextMode: boolean
+) {
+  return activeEditor === 'comment' ? commentIsPlainTextMode : descriptionIsPlainTextMode;
+}

--- a/BoardOil.Web/src/board/realtime/boardRealtime.test.ts
+++ b/BoardOil.Web/src/board/realtime/boardRealtime.test.ts
@@ -91,6 +91,7 @@ describe('boardRealtime', () => {
       onCardUpdated: vi.fn(),
       onCardDeleted: vi.fn(),
       onCardMoved: vi.fn(),
+      onCommentCreated: vi.fn(),
       onResync
     });
 
@@ -112,6 +113,7 @@ describe('boardRealtime', () => {
       onCardUpdated: vi.fn(),
       onCardDeleted: vi.fn(),
       onCardMoved: vi.fn(),
+      onCommentCreated: vi.fn(),
       onResync
     });
 
@@ -119,6 +121,36 @@ describe('boardRealtime', () => {
     await connection.eventHandlers.ResyncRequested?.();
 
     expect(onResync).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards comment created events to handler', async () => {
+    const onCommentCreated = vi.fn(async () => undefined);
+    const { createBoardRealtime } = await import('./boardRealtime');
+    const realtime = createBoardRealtime({
+      onColumnCreated: vi.fn(),
+      onColumnUpdated: vi.fn(),
+      onColumnDeleted: vi.fn(),
+      onCardCreated: vi.fn(),
+      onCardUpdated: vi.fn(),
+      onCardDeleted: vi.fn(),
+      onCardMoved: vi.fn(),
+      onCommentCreated,
+      onResync: vi.fn()
+    });
+
+    const comment = {
+      id: 123,
+      cardId: 55,
+      authorUserId: 4,
+      text: 'hello',
+      createdAtUtc: '2026-05-02T07:00:00.0000000Z'
+    };
+
+    await realtime.connect(42);
+    await connection.eventHandlers.CommentCreated?.(comment);
+
+    expect(onCommentCreated).toHaveBeenCalledTimes(1);
+    expect(onCommentCreated).toHaveBeenCalledWith(comment);
   });
 
   it('still stops connection when unsubscribe fails during disconnect', async () => {
@@ -131,6 +163,7 @@ describe('boardRealtime', () => {
       onCardUpdated: vi.fn(),
       onCardDeleted: vi.fn(),
       onCardMoved: vi.fn(),
+      onCommentCreated: vi.fn(),
       onResync: vi.fn()
     });
     connection.invoke.mockImplementation(async (method: string) => {
@@ -171,6 +204,7 @@ describe('boardRealtime', () => {
       onCardUpdated: vi.fn(),
       onCardDeleted: vi.fn(),
       onCardMoved: vi.fn(),
+      onCommentCreated: vi.fn(),
       onResync: vi.fn()
     });
 

--- a/BoardOil.Web/src/board/realtime/boardRealtime.ts
+++ b/BoardOil.Web/src/board/realtime/boardRealtime.ts
@@ -1,6 +1,6 @@
 import { HubConnection, HubConnectionBuilder, HubConnectionState, LogLevel } from '@microsoft/signalr';
 import { boardHubUrl } from '../../shared/api/config';
-import type { Card, Column } from '../../shared/types/boardTypes';
+import type { Card, CardComment, Column } from '../../shared/types/boardTypes';
 
 type RealtimeHandlers = {
   onColumnCreated: (column: Column) => Promise<unknown> | unknown;
@@ -10,6 +10,7 @@ type RealtimeHandlers = {
   onCardUpdated: (card: Card) => Promise<unknown> | unknown;
   onCardDeleted: (cardId: number) => Promise<unknown> | unknown;
   onCardMoved: (card: Card) => Promise<unknown> | unknown;
+  onCommentCreated: (comment: CardComment) => Promise<unknown> | unknown;
   onResync: () => Promise<unknown> | unknown;
 };
 
@@ -114,6 +115,10 @@ export function createBoardRealtime(handlers: RealtimeHandlers) {
       hubConnection.on('CardMoved', async (card: Card) => {
         logRealtime('Event: CardMoved', { cardId: card.id, boardColumnId: card.boardColumnId });
         await handlers.onCardMoved(card);
+      });
+      hubConnection.on('CommentCreated', async (comment: CardComment) => {
+        logRealtime('Event: CommentCreated', { commentId: comment.id, cardId: comment.cardId });
+        await handlers.onCommentCreated(comment);
       });
       hubConnection.on('ResyncRequested', async () => {
         logRealtime('Event: ResyncRequested');

--- a/BoardOil.Web/src/board/stores/boardStore.ts
+++ b/BoardOil.Web/src/board/stores/boardStore.ts
@@ -49,6 +49,7 @@ export const useBoardStore = defineStore('board', () => {
     onCardUpdated: cardStore.upsertCard,
     onCardDeleted: cardStore.removeCard,
     onCardMoved: cardStore.upsertCard,
+    onCommentCreated: commentStore.upsertCardComment,
     onResync: async () => {
       if (currentBoardId.value !== null) {
         await loadBoard(currentBoardId.value);

--- a/BoardOil.Web/src/board/stores/boardStore.ts
+++ b/BoardOil.Web/src/board/stores/boardStore.ts
@@ -6,6 +6,7 @@ import { createBoardRealtime } from '../realtime/boardRealtime';
 import { useUiFeedbackStore } from '../../shared/stores/uiFeedbackStore';
 import { useCardStore } from './cardStore';
 import { useCardTypeStore } from './cardTypeStore';
+import { useCommentStore } from './commentStore';
 import type { Board, BoardSummary, Column } from '../../shared/types/boardTypes';
 import type { AppError } from '../../shared/types/appError';
 import type { Result } from '../../shared/types/result';
@@ -22,6 +23,7 @@ export const useBoardStore = defineStore('board', () => {
   const feedback = useUiFeedbackStore();
   const cardStore = useCardStore();
   const cardTypeStore = useCardTypeStore();
+  const commentStore = useCommentStore();
   const api = createBoardApi();
   const board = computed<Board | null>(() => {
     if (!boardShell.value) {
@@ -89,6 +91,7 @@ export const useBoardStore = defineStore('board', () => {
     currentBoardId.value = null;
     isLoadingBoard.value = false;
     cardStore.dispose();
+    commentStore.dispose();
   }
 
   async function loadBoard(boardId: number) {
@@ -102,6 +105,7 @@ export const useBoardStore = defineStore('board', () => {
       boardShell.value = null;
       currentBoardId.value = null;
       cardStore.dispose();
+      commentStore.dispose();
       reportError(result.error);
       return false;
     }
@@ -110,6 +114,7 @@ export const useBoardStore = defineStore('board', () => {
     currentBoardId.value = boardId;
     boardShell.value = stripBoardCards(sortedBoard);
     cardStore.replaceBoardCards(boardId, sortedBoard.columns);
+    commentStore.dispose();
     feedback.clearError();
     return true;
   }

--- a/BoardOil.Web/src/board/stores/commentStore.ts
+++ b/BoardOil.Web/src/board/stores/commentStore.ts
@@ -35,8 +35,7 @@ export const useCommentStore = defineStore('comment', () => {
       return result;
     }
 
-    const existingComments = commentsByCardId.value[cardId] ?? [];
-    setCardComments(cardId, [result.data, ...existingComments]);
+    upsertCardComment(result.data);
     return result;
   }
 
@@ -51,8 +50,14 @@ export const useCommentStore = defineStore('comment', () => {
   function setCardComments(cardId: number, comments: CardComment[]) {
     commentsByCardId.value = {
       ...commentsByCardId.value,
-      [cardId]: comments.map(comment => ({ ...comment }))
+      [cardId]: normalizeComments(comments)
     };
+  }
+
+  function upsertCardComment(comment: CardComment) {
+    const existingComments = commentsByCardId.value[comment.cardId] ?? [];
+    const withoutExisting = existingComments.filter(existing => existing.id !== comment.id);
+    setCardComments(comment.cardId, [comment, ...withoutExisting]);
   }
 
   async function runBusy<T>(operation: () => Promise<Result<T, AppError>>) {
@@ -77,6 +82,33 @@ export const useCommentStore = defineStore('comment', () => {
     dispose,
     loadCardComments,
     addCardComment,
-    getCommentsForCard
+    getCommentsForCard,
+    upsertCardComment
   };
 });
+
+function normalizeComments(comments: CardComment[]) {
+  return comments
+    .map(comment => ({ ...comment }))
+    .sort(compareCommentsDescending);
+}
+
+function compareCommentsDescending(left: CardComment, right: CardComment) {
+  if (left.createdAtUtc > right.createdAtUtc) {
+    return -1;
+  }
+
+  if (left.createdAtUtc < right.createdAtUtc) {
+    return 1;
+  }
+
+  if (left.id > right.id) {
+    return -1;
+  }
+
+  if (left.id < right.id) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/BoardOil.Web/src/board/stores/commentStore.ts
+++ b/BoardOil.Web/src/board/stores/commentStore.ts
@@ -1,0 +1,82 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { createBoardApi } from '../../shared/api/boardApi';
+import { useUiFeedbackStore } from '../../shared/stores/uiFeedbackStore';
+import type { CardComment } from '../../shared/types/boardTypes';
+import type { AppError } from '../../shared/types/appError';
+import type { Result } from '../../shared/types/result';
+
+type CommentsByCardIdMap = Record<number, CardComment[]>;
+
+export const useCommentStore = defineStore('comment', () => {
+  const commentsByCardId = ref<CommentsByCardIdMap>({});
+  const busy = ref(false);
+  const feedback = useUiFeedbackStore();
+  const api = createBoardApi();
+
+  function dispose() {
+    commentsByCardId.value = {};
+    busy.value = false;
+  }
+
+  async function loadCardComments(boardId: number, cardId: number) {
+    const result = await runBusy(() => api.getCardComments(boardId, cardId));
+    if (!result.ok) {
+      return result;
+    }
+
+    setCardComments(cardId, result.data);
+    return result;
+  }
+
+  async function addCardComment(boardId: number, cardId: number, text: string) {
+    const result = await runBusy(() => api.createCardComment(boardId, cardId, text));
+    if (!result.ok) {
+      return result;
+    }
+
+    const existingComments = commentsByCardId.value[cardId] ?? [];
+    setCardComments(cardId, [result.data, ...existingComments]);
+    return result;
+  }
+
+  function getCommentsForCard(cardId: number | null) {
+    if (cardId === null) {
+      return [];
+    }
+
+    return commentsByCardId.value[cardId] ?? [];
+  }
+
+  function setCardComments(cardId: number, comments: CardComment[]) {
+    commentsByCardId.value = {
+      ...commentsByCardId.value,
+      [cardId]: comments.map(comment => ({ ...comment }))
+    };
+  }
+
+  async function runBusy<T>(operation: () => Promise<Result<T, AppError>>) {
+    busy.value = true;
+    try {
+      const result = await operation();
+      if (!result.ok) {
+        feedback.setError(result.error.message);
+      } else {
+        feedback.clearError();
+      }
+
+      return result;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  return {
+    commentsByCardId,
+    busy,
+    dispose,
+    loadCardComments,
+    addCardComment,
+    getCommentsForCard
+  };
+});

--- a/BoardOil.Web/src/shared/api/boardApi.ts
+++ b/BoardOil.Web/src/shared/api/boardApi.ts
@@ -7,6 +7,7 @@ import type {
   BoardMemberRole,
   BoardSummary,
   Card,
+  CardComment,
   CardType,
   Column,
   Tag,
@@ -190,6 +191,19 @@ export function createBoardApi() {
 
   async function deleteCard(boardId: number, cardId: number): Promise<Result<void, AppError>> {
     return deleteJson(`/api/boards/${boardId}/cards/${cardId}`);
+  }
+
+  async function getCardComments(boardId: number, cardId: number): Promise<Result<CardComment[], AppError>> {
+    const envelopeResult = await getEnvelope<CardComment[]>(`/api/boards/${boardId}/cards/${cardId}/comments`);
+    if (!envelopeResult.ok) {
+      return envelopeResult;
+    }
+
+    return ok(envelopeResult.data.data ?? []);
+  }
+
+  async function createCardComment(boardId: number, cardId: number, text: string): Promise<Result<CardComment, AppError>> {
+    return postData<CardComment>(`/api/boards/${boardId}/cards/${cardId}/comments`, { text });
   }
 
   async function archiveCard(boardId: number, cardId: number): Promise<Result<void, AppError>> {
@@ -388,6 +402,8 @@ export function createBoardApi() {
     saveCard,
     moveCard,
     deleteCard,
+    getCardComments,
+    createCardComment,
     archiveCard,
     archiveCards,
     unarchiveCard,

--- a/BoardOil.Web/src/shared/components/MdEditor.vue
+++ b/BoardOil.Web/src/shared/components/MdEditor.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="md-editor" :style="{ '--md-editor-min-height': minHeight }">
     <MdEditorToolbar
+      v-if="showToolbar"
       :state="toolbarState"
       :is-plain-text-mode="isPlainTextMode"
       @action="onToolbarAction"
@@ -43,6 +44,7 @@ import { computed, ref, watch } from 'vue';
 import MdLinkDialog from './MdLinkDialog.vue';
 import MdEditorToolbar from './MdEditorToolbar.vue';
 import { mdEditorToolbarActions, type MdEditorToolbarActionEvent, type MdEditorToolbarActionId, type MdEditorToolbarActionState } from './mdEditorToolbarActions';
+import { runMdEditorToolbarAction } from './mdEditorController';
 import { isHttpOrHttpsUrl } from '../utils/linkUrl';
 
 const props = withDefaults(defineProps<{
@@ -50,16 +52,20 @@ const props = withDefaults(defineProps<{
   ariaLabel?: string;
   maxLength?: number;
   minHeight?: string;
+  showToolbar?: boolean;
 }>(), {
   ariaLabel: 'Markdown editor',
   maxLength: 20_000,
-  minHeight: '12rem'
+  minHeight: '12rem',
+  showToolbar: true
 });
 
 const emit = defineEmits<{
   'update:modelValue': [value: string];
   focus: [];
   blur: [];
+  'toolbar-state-change': [value: Partial<Record<MdEditorToolbarActionId, MdEditorToolbarActionState>>];
+  'plain-text-mode-change': [value: boolean];
 }>();
 
 const normalisedModelValue = computed(() => normaliseMarkdown(props.modelValue ?? ''));
@@ -157,30 +163,20 @@ const toolbarState = computed<Partial<Record<MdEditorToolbarActionId, MdEditorTo
   return state;
 });
 
+watch(toolbarState, value => {
+  emit('toolbar-state-change', value);
+}, { immediate: true });
+
+watch(isPlainTextMode, value => {
+  emit('plain-text-mode-change', value);
+}, { immediate: true });
+
 function onToolbarAction(actionEvent: MdEditorToolbarActionEvent) {
-  if (isPlainTextMode.value) {
-    return;
-  }
+  runMdEditorToolbarAction(actionEvent, tiptapEditor.value ?? null, isPlainTextMode.value, openLinkDialog);
+}
 
-  const editor = tiptapEditor.value;
-  if (!editor) {
-    return;
-  }
-
-  const nextActionEvent: MdEditorToolbarActionEvent = actionEvent.id === 'heading'
-    ? { id: actionEvent.id, headingLevel: actionEvent.headingLevel ?? 1 }
-    : { id: actionEvent.id };
-
-  const action = mdEditorToolbarActions.find(x => x.id === nextActionEvent.id);
-  if (!action) {
-    return;
-  }
-
-  if (!action.canRun(editor, nextActionEvent)) {
-    return;
-  }
-
-  action.run(editor, { openLinkDialog }, nextActionEvent);
+function runToolbarAction(actionEvent: MdEditorToolbarActionEvent) {
+  onToolbarAction(actionEvent);
 }
 
 function togglePlainTextMode() {
@@ -214,6 +210,11 @@ function onPlainTextInput(value: string) {
 
   emit('update:modelValue', nextValue);
 }
+
+defineExpose({
+  runToolbarAction,
+  togglePlainTextMode
+});
 
 function openLinkDialog(editor: TiptapEditor) {
   editor.chain().focus().run();

--- a/BoardOil.Web/src/shared/components/mdEditorController.test.ts
+++ b/BoardOil.Web/src/shared/components/mdEditorController.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { normaliseToolbarActionEvent, runMdEditorToolbarAction } from './mdEditorController';
+import type { MdEditorToolbarActionEvent } from './mdEditorToolbarActions';
+
+function createFakeEditor(canRun = true) {
+  const toggleHeading = vi.fn(() => ({ run: () => canRun }));
+  const canChainRun = vi.fn(() => canRun);
+  const actionChainRun = vi.fn(() => true);
+
+  const canChain = () => ({
+    focus: () => ({
+      toggleBold: () => ({
+        run: canChainRun
+      }),
+      toggleHeading
+    })
+  });
+
+  const chain = () => ({
+    focus: () => ({
+      toggleBold: () => ({
+        run: actionChainRun
+      }),
+      toggleHeading
+    })
+  });
+
+  return {
+    editor: {
+      can: () => ({ chain: canChain }),
+      chain
+    } as any,
+    spies: {
+      toggleHeading,
+      canChainRun,
+      actionChainRun
+    }
+  };
+}
+
+describe('normaliseToolbarActionEvent', () => {
+  it('normalises heading events with default level 1', () => {
+    expect(normaliseToolbarActionEvent({ id: 'heading' })).toEqual({ id: 'heading', headingLevel: 1 });
+  });
+
+  it('preserves heading level when provided', () => {
+    expect(normaliseToolbarActionEvent({ id: 'heading', headingLevel: 3 })).toEqual({ id: 'heading', headingLevel: 3 });
+  });
+
+  it('removes irrelevant properties from non-heading actions', () => {
+    expect(normaliseToolbarActionEvent({ id: 'bold', headingLevel: 3 } as MdEditorToolbarActionEvent)).toEqual({ id: 'bold' });
+  });
+});
+
+describe('runMdEditorToolbarAction', () => {
+  it('does not run actions in plain text mode', () => {
+    const { editor } = createFakeEditor(true);
+    const openLinkDialog = vi.fn();
+
+    const ran = runMdEditorToolbarAction({ id: 'bold' }, editor, true, openLinkDialog);
+
+    expect(ran).toBe(false);
+    expect(openLinkDialog).not.toHaveBeenCalled();
+  });
+
+  it('does not run actions when editor is missing', () => {
+    const ran = runMdEditorToolbarAction({ id: 'bold' }, null, false, vi.fn());
+    expect(ran).toBe(false);
+  });
+
+  it('runs heading action with default heading level when not provided', () => {
+    const { editor, spies } = createFakeEditor(true);
+
+    const ran = runMdEditorToolbarAction({ id: 'heading' }, editor, false, vi.fn());
+
+    expect(ran).toBe(true);
+    expect(spies.toggleHeading).toHaveBeenCalledWith({ level: 1 });
+  });
+
+  it('does not run when action cannot run', () => {
+    const { editor } = createFakeEditor(false);
+    const ran = runMdEditorToolbarAction({ id: 'bold' }, editor, false, vi.fn());
+    expect(ran).toBe(false);
+  });
+});

--- a/BoardOil.Web/src/shared/components/mdEditorController.ts
+++ b/BoardOil.Web/src/shared/components/mdEditorController.ts
@@ -1,0 +1,33 @@
+import type { Editor as TiptapEditor } from '@tiptap/core';
+import { mdEditorToolbarActions, type MdEditorToolbarActionEvent } from './mdEditorToolbarActions';
+
+export function normaliseToolbarActionEvent(actionEvent: MdEditorToolbarActionEvent): MdEditorToolbarActionEvent {
+  if (actionEvent.id !== 'heading') {
+    return { id: actionEvent.id };
+  }
+
+  return {
+    id: actionEvent.id,
+    headingLevel: actionEvent.headingLevel ?? 1
+  };
+}
+
+export function runMdEditorToolbarAction(
+  actionEvent: MdEditorToolbarActionEvent,
+  editor: TiptapEditor | null,
+  isPlainTextMode: boolean,
+  openLinkDialog: (editor: TiptapEditor) => void
+) {
+  if (isPlainTextMode || !editor) {
+    return false;
+  }
+
+  const nextActionEvent = normaliseToolbarActionEvent(actionEvent);
+  const action = mdEditorToolbarActions.find(x => x.id === nextActionEvent.id);
+  if (!action || !action.canRun(editor, nextActionEvent)) {
+    return false;
+  }
+
+  action.run(editor, { openLinkDialog }, nextActionEvent);
+  return true;
+}

--- a/BoardOil.Web/src/shared/types/boardTypes.ts
+++ b/BoardOil.Web/src/shared/types/boardTypes.ts
@@ -12,6 +12,14 @@ export type CardTag = TagPresentation & {
   name: string;
 };
 
+export type CardComment = {
+  id: number;
+  cardId: number;
+  authorUserId: number;
+  text: string;
+  createdAtUtc: string;
+};
+
 export type Card = {
   id: number;
   boardColumnId: number;

--- a/BoardOil.Web/src/shared/types/boardTypes.ts
+++ b/BoardOil.Web/src/shared/types/boardTypes.ts
@@ -15,7 +15,7 @@ export type CardTag = TagPresentation & {
 export type CardComment = {
   id: number;
   cardId: number;
-  authorUserId: number;
+  authorUserId: number | null;
   text: string;
   createdAtUtc: string;
   authorDisplayName?: string | null;

--- a/BoardOil.Web/src/shared/types/boardTypes.ts
+++ b/BoardOil.Web/src/shared/types/boardTypes.ts
@@ -18,6 +18,8 @@ export type CardComment = {
   authorUserId: number;
   text: string;
   createdAtUtc: string;
+  authorDisplayName?: string | null;
+  authorImageRelativePath?: string | null;
 };
 
 export type Card = {


### PR DESCRIPTION
## Summary
This PR delivers the full `#247` comment-support epic as a set of reviewable vertical slices now combined on the `comments` branch.

It adds end-to-end card comments in the app, then layers on:
- polished card editor layout and shared scroll behavior
- comment author metadata display with best-effort live user resolution
- markdown authoring/rendering for comments
- MCP support for reading and creating comments
- realtime comment-created updates
- import/export support with portability-oriented email remapping
- archive/unarchive support for comments, including deletion-safe attribution fallback

## Key changes
- Added a dedicated comment store and comment create/list flow in the card editor UI.
- Added persistence, service, API, and contract support for card comments.
- Made comment author linkage nullable and privacy-first at runtime, with best-effort relinking by current user data.
- Added MCP `add-comment` support and extended `card_get` to include comments.
- Added realtime propagation for newly created comments.
- Included comments in board package import/export and archived card snapshots.
- Updated archive loading to use split queries and raised archived snapshot size allowance to `2 MiB`.

## Validation
Key focused validation run during final archive work:
- `dotnet test BoardOil.Services.Tests/BoardOil.Services.Tests.csproj -maxcpucount:1 -nodeReuse:false --filter "FullyQualifiedName~ArchivedCardSnapshotSerialiserTests|FullyQualifiedName~CardArchiveServiceTests|FullyQualifiedName~CardUnarchiveServiceV1Tests"`

Additional targeted tests were added across API, services, MCP, realtime, import/export, and web editor behavior as part of the slice-by-slice delivery.

## Story coverage
- `#247.1` Thin end-to-end comments
- `#247.2` Card dialog layout behavior
- `#247.3` Comment identity display
- `#247.4` Markdown authoring/rendering
- `#247.5` MCP comment support
- `#247.6` Realtime comment updates
- `#247.7` Import/export comments
- `#247.8` Archive behavior for comments
- `#247.9` Comment author model refactor