### PR TITLE
#729 Improve backend test setup and timing diagnostics

### DIFF
--- a/AGENTS/Testing.md
+++ b/AGENTS/Testing.md
@@ -104,6 +104,7 @@ Use repository scripts to keep local feedback fast and consistent:
   - CI-like full local run (backend restore/build/tests + web check/test)
   - supports suite overrides: `--backend-only`, `--web-only`
   - supports output overrides: `--compact`, `--verbose`
+  - supports `--profile-api` to print the ten slowest API test classes by cumulative test time
 
 Convenience wrappers:
 - `scripts/test-fast.sh`, `scripts/test-full.sh`, `scripts/test-fast.ps1`, and `scripts/test-full.ps1` delegate to the `.mjs` scripts.
@@ -122,6 +123,7 @@ The repository test scripts default to compact output when they detect an agent 
 
 - hides successful restore/build/check command output
 - prints concise pass summaries for xUnit and Vitest test runs
+- prints total and named build/test phase timings after a successful script run
 - replays full stdout/stderr for any failed command before reporting the failed suite
 - passes `--no-progress --no-ansi` to xUnit v3 test applications
 - lets Vitest use its `agent` reporter with `silent: 'passed-only'`

--- a/BoardOil.Api.Tests/Infrastructure/BoardOilApiFactory.cs
+++ b/BoardOil.Api.Tests/Infrastructure/BoardOilApiFactory.cs
@@ -1,16 +1,23 @@
 using BoardOil.Abstractions.Auth;
+using BoardOil.Ef.DependencyInjection;
+using BoardOil.Services.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace BoardOil.Api.Tests.Infrastructure;
 
 public sealed class BoardOilApiFactory : WebApplicationFactory<Program>
 {
     public const string DefaultSigningKey = "boardoil-api-tests-signing-key-12345678901234567890";
+
+    private static readonly object DatabaseTemplateLock = new();
+    private static readonly Lazy<SqliteConnection> DatabaseTemplate = new(CreateDatabaseTemplate);
 
     private readonly string _databasePath;
     private readonly bool _allowInsecureCookies;
@@ -103,5 +110,59 @@ public sealed class BoardOilApiFactory : WebApplicationFactory<Program>
             services.AddSingleton<IPasswordHashService, FastPasswordHashService>();
             _configureTestServices?.Invoke(services);
         });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        InitialiseDatabaseFromTemplate();
+        return base.CreateHost(builder);
+    }
+
+    private void InitialiseDatabaseFromTemplate()
+    {
+        if (File.Exists(_databasePath))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        lock (DatabaseTemplateLock)
+        {
+            if (File.Exists(_databasePath))
+            {
+                return;
+            }
+
+            using var destination = new SqliteConnection($"Data Source={_databasePath}");
+            destination.Open();
+            DatabaseTemplate.Value.BackupDatabase(destination);
+        }
+    }
+
+    private static SqliteConnection CreateDatabaseTemplate()
+    {
+        var connection = new SqliteConnection(
+            $"Data Source=file:boardoil-api-tests-template-{Guid.NewGuid():N}?mode=memory&cache=shared");
+        connection.Open();
+
+        try
+        {
+            using var serviceProvider = new ServiceCollection()
+                .AddBoardOilServices()
+                .AddBoardOilEfInfrastructure(connection.ConnectionString)
+                .BuildServiceProvider();
+            serviceProvider.InitializeBoardOilEfInfrastructureAsync().GetAwaiter().GetResult();
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 }

--- a/BoardOil.Services.Tests/Infrastructure/SqliteTestHarness.cs
+++ b/BoardOil.Services.Tests/Infrastructure/SqliteTestHarness.cs
@@ -6,6 +6,9 @@ namespace BoardOil.Services.Tests.Infrastructure;
 
 public sealed class SqliteTestHarness : IAsyncDisposable
 {
+    private static readonly object DatabaseTemplateLock = new();
+    private static readonly Lazy<SqliteConnection> DatabaseTemplate = new(CreateDatabaseTemplate);
+
     private readonly SqliteConnection _connection;
 
     public DbContextOptions<BoardOilDbContext> Options { get; }
@@ -21,16 +24,37 @@ public sealed class SqliteTestHarness : IAsyncDisposable
         var connection = new SqliteConnection("DataSource=:memory:");
         await connection.OpenAsync();
 
+        lock (DatabaseTemplateLock)
+        {
+            DatabaseTemplate.Value.BackupDatabase(connection);
+        }
+
         var options = new DbContextOptionsBuilder<BoardOilDbContext>()
             .UseSqlite(connection)
             .Options;
 
-        await using (var db = new BoardOilDbContext(options))
-        {
-            await db.Database.EnsureCreatedAsync();
-        }
-
         return new SqliteTestHarness(connection, options);
+    }
+
+    private static SqliteConnection CreateDatabaseTemplate()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        try
+        {
+            var options = new DbContextOptionsBuilder<BoardOilDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            using var db = new BoardOilDbContext(options);
+            db.Database.EnsureCreated();
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 
     public BoardOilDbContext CreateDbContext() => new(Options);

--- a/BoardOil.Services.Tests/Infrastructure/SqliteTestHarnessGuardTests.cs
+++ b/BoardOil.Services.Tests/Infrastructure/SqliteTestHarnessGuardTests.cs
@@ -1,3 +1,4 @@
+using BoardOil.Data.Abstractions.Entities;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -47,5 +48,31 @@ public sealed class SqliteTestHarnessGuardTests : IAsyncLifetime
         // Assert
         Assert.Same(firstConnection, secondConnection);
         Assert.Equal(System.Data.ConnectionState.Open, firstConnection.State);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldProvideAnIsolatedDatabaseFromTemplate()
+    {
+        // Arrange
+        await using var firstHarness = await SqliteTestHarness.CreateAsync();
+        await using var secondHarness = await SqliteTestHarness.CreateAsync();
+        await using var firstDbContext = firstHarness.CreateDbContext();
+        await using var secondDbContext = secondHarness.CreateDbContext();
+        firstDbContext.Users.Add(new EntityUser
+        {
+            UserName = "first-user",
+            Email = "first-user@example.com",
+            NormalisedEmail = "FIRST-USER@EXAMPLE.COM",
+            PasswordHash = "test-hash",
+            Role = UserRole.Admin,
+            IsActive = true,
+        });
+
+        // Act
+        await firstDbContext.SaveChangesAsync();
+        var secondDatabaseUserCount = await secondDbContext.Users.CountAsync();
+
+        // Assert
+        Assert.Equal(0, secondDatabaseUserCount);
     }
 }

--- a/scripts/test-fast.mjs
+++ b/scripts/test-fast.mjs
@@ -78,6 +78,8 @@ function resolveOutputMode() {
 
 const outputMode = resolveOutputMode();
 const compactOutput = outputMode === "compact";
+const timings = [];
+const startedAt = Date.now();
 
 function isAgentEnvironment() {
   return (
@@ -124,7 +126,8 @@ function commandFailed(result) {
   return Boolean(result.error);
 }
 
-function run(command, commandArgs, cwd = rootDir, options = {}) {
+function run(label, command, commandArgs, cwd = rootDir, options = {}) {
+  const stepStartedAt = Date.now();
   const result = spawnSync(command, commandArgs, {
     cwd,
     stdio: compactOutput ? "pipe" : "inherit",
@@ -132,6 +135,7 @@ function run(command, commandArgs, cwd = rootDir, options = {}) {
     encoding: "utf8",
     env: childEnv()
   });
+  timings.push({ label, elapsedMilliseconds: Date.now() - stepStartedAt });
 
   if (compactOutput && options.printSuccessOutput) {
     printCapturedOutput(result);
@@ -159,7 +163,7 @@ function restoreBackendOnce() {
   }
 
   console.log("[test-fast] Restoring backend solution (one-time fallback)");
-  const restore = run("dotnet", ["restore", "BoardOil.slnx", "--locked-mode", "-maxcpucount:1", "-nodeReuse:false"]);
+  const restore = run("Backend restore", "dotnet", ["restore", "BoardOil.slnx", "--locked-mode", "-maxcpucount:1", "-nodeReuse:false"]);
   if (restore.status !== 0) {
     throw new Error("dotnet restore failed");
   }
@@ -168,7 +172,7 @@ function restoreBackendOnce() {
 }
 
 function buildTestProjectRelease(projectPath) {
-  const firstBuild = run("dotnet", [
+  const firstBuild = run(`Build ${projectPath}`, "dotnet", [
     "build",
     projectPath,
     "--configuration",
@@ -185,7 +189,7 @@ function buildTestProjectRelease(projectPath) {
   console.log(`[test-fast] Build without restore failed for ${projectPath}; retrying after restore.`);
   restoreBackendOnce();
 
-  const secondBuild = run("dotnet", [
+  const secondBuild = run(`Build ${projectPath} after restore`, "dotnet", [
     "build",
     projectPath,
     "--configuration",
@@ -203,7 +207,7 @@ function buildTestProjectRelease(projectPath) {
 function runApiReleaseTests() {
   console.log("[test-fast] Running API fast tests (Release, excludes slow integration classes)");
   buildTestProjectRelease(API_TEST_PROJECT);
-  const result = run("dotnet", [
+  const result = run("API fast tests", "dotnet", [
     API_TEST_DLL,
     "--filter-not-class",
     FAST_API_EXCLUDE_CLASS_FILTER,
@@ -219,7 +223,7 @@ function runApiReleaseTests() {
 function runServicesReleaseTests() {
   console.log("[test-fast] Running Services fast tests (Release)");
   buildTestProjectRelease(SERVICES_TEST_PROJECT);
-  const result = run("dotnet", [SERVICES_TEST_DLL, ...compactTestRunnerArgs()]);
+  const result = run("Services fast tests", "dotnet", [SERVICES_TEST_DLL, ...compactTestRunnerArgs()]);
   if (result.status !== 0) {
     throw new Error("services-fast failed");
   }
@@ -230,7 +234,7 @@ function runServicesReleaseTests() {
 function runDevReleaseTests() {
   console.log("[test-fast] Running Dev orchestrator tests (Release)");
   buildTestProjectRelease(DEV_TEST_PROJECT);
-  const result = run("dotnet", [DEV_TEST_DLL, ...compactTestRunnerArgs()]);
+  const result = run("Dev orchestrator tests", "dotnet", [DEV_TEST_DLL, ...compactTestRunnerArgs()]);
   if (result.status !== 0) {
     throw new Error("dev-fast failed");
   }
@@ -240,7 +244,7 @@ function runDevReleaseTests() {
 
 function runWebChecks() {
   console.log("[test-fast] Running web checks");
-  const check = run("npm", npmRunArgs("check"), path.join(rootDir, "BoardOil.Web"));
+  const check = run("Web check", "npm", npmRunArgs("check"), path.join(rootDir, "BoardOil.Web"));
   if (check.status !== 0) {
     throw new Error("web-checks failed at npm run check");
   }
@@ -249,7 +253,7 @@ function runWebChecks() {
     console.log("[test-fast] Web check: passed");
   }
 
-  const test = run("npm", npmRunArgs("test"), path.join(rootDir, "BoardOil.Web"));
+  const test = run("Web tests", "npm", npmRunArgs("test"), path.join(rootDir, "BoardOil.Web"));
   if (test.status !== 0) {
     throw new Error("web-checks failed at npm test");
   }
@@ -340,7 +344,19 @@ function finish() {
     process.exit(1);
   }
 
+  printTimingSummary();
   console.log("[test-fast] Done");
+}
+
+function printTimingSummary() {
+  const timingDetails = timings
+    .map(timing => `${timing.label} ${formatElapsedTime(timing.elapsedMilliseconds)}`)
+    .join("; ");
+  console.log(`[test-fast] Timing: ${formatElapsedTime(Date.now() - startedAt)} total; ${timingDetails}`);
+}
+
+function formatElapsedTime(elapsedMilliseconds) {
+  return `${(elapsedMilliseconds / 1000).toFixed(1)}s`;
 }
 
 if (mode !== "auto") {
@@ -358,7 +374,7 @@ if (mode !== "auto") {
     runSuite("services-fast", runServicesReleaseTests);
   } else if (mode === "full") {
     runSuite("full-lane", () => {
-      const full = run("node", ["scripts/test-full.mjs"], rootDir, { printSuccessOutput: true });
+      const full = run("Full test lane", "node", ["scripts/test-full.mjs"], rootDir, { printSuccessOutput: true });
       if (full.status !== 0) {
         throw new Error("full-lane failed");
       }

--- a/scripts/test-full.mjs
+++ b/scripts/test-full.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +11,7 @@ const args = process.argv.slice(2);
 let runBackend = true;
 let runWeb = true;
 let outputModeOverride = null;
+let profileApi = false;
 
 for (const arg of args) {
   if (arg === "--backend-only") {
@@ -27,8 +29,13 @@ for (const arg of args) {
     continue;
   }
 
+  if (arg === "--profile-api") {
+    profileApi = true;
+    continue;
+  }
+
   if (arg === "--help" || arg === "-h") {
-    console.log("Usage: node scripts/test-full.mjs [--backend-only|--web-only] [--compact|--verbose]");
+    console.log("Usage: node scripts/test-full.mjs [--backend-only|--web-only] [--compact|--verbose] [--profile-api]");
     process.exit(0);
   }
 
@@ -70,6 +77,8 @@ function resolveOutputMode() {
 
 const outputMode = resolveOutputMode();
 const compactOutput = outputMode === "compact";
+const timings = [];
+const startedAt = Date.now();
 
 function isAgentEnvironment() {
   return (
@@ -116,7 +125,8 @@ function commandFailed(result) {
   return Boolean(result.error);
 }
 
-function run(command, commandArgs, cwd = rootDir) {
+function run(label, command, commandArgs, cwd = rootDir) {
+  const stepStartedAt = Date.now();
   const result = spawnSync(command, commandArgs, {
     cwd,
     stdio: compactOutput ? "pipe" : "inherit",
@@ -124,6 +134,7 @@ function run(command, commandArgs, cwd = rootDir) {
     encoding: "utf8",
     env: childEnv()
   });
+  timings.push({ label, elapsedMilliseconds: Date.now() - stepStartedAt });
 
   if (compactOutput && commandFailed(result)) {
     printCapturedOutput(result);
@@ -147,6 +158,21 @@ function compactTestRunnerArgs() {
   }
 
   return ["--no-progress", "--no-ansi"];
+}
+
+function testRunnerArgs(reportPath = null) {
+  const runnerArgs = compactTestRunnerArgs();
+  if (reportPath) {
+    runnerArgs.push(
+      "--results-directory",
+      path.dirname(reportPath),
+      "--report-xunit",
+      "--report-xunit-filename",
+      path.basename(reportPath)
+    );
+  }
+
+  return runnerArgs;
 }
 
 function npmRunArgs(scriptName) {
@@ -204,29 +230,84 @@ function printVitestSummary(label, output) {
   console.log(`[test-full] ${label}: passed`);
 }
 
+function printApiClassProfile(reportPath) {
+  const report = fs.readFileSync(reportPath, "utf8");
+  const classTimings = new Map();
+  for (const match of report.matchAll(/<test\s+([^>]+)>/g)) {
+    const attributes = match[1];
+    const className = readXmlAttribute(attributes, "type");
+    const elapsedSeconds = Number.parseFloat(readXmlAttribute(attributes, "time") ?? "");
+    if (!className || !Number.isFinite(elapsedSeconds)) {
+      continue;
+    }
+
+    const current = classTimings.get(className) ?? { elapsedSeconds: 0, tests: 0 };
+    current.elapsedSeconds += elapsedSeconds;
+    current.tests++;
+    classTimings.set(className, current);
+  }
+
+  const slowestClasses = [...classTimings.entries()]
+    .sort((left, right) => right[1].elapsedSeconds - left[1].elapsedSeconds)
+    .slice(0, 10);
+  console.log("[test-full] API slowest classes (cumulative test time):");
+  for (const [className, timing] of slowestClasses) {
+    console.log(`  ${className}: ${timing.elapsedSeconds.toFixed(1)}s across ${timing.tests} tests`);
+  }
+}
+
+function readXmlAttribute(attributes, name) {
+  const match = attributes.match(new RegExp(`${name}="([^"]*)"`));
+  return match?.[1]
+    ?.replaceAll("&quot;", "\"")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
 if (runBackend) {
   console.log("[test-full] Backend: restore + build + tests");
-  run("dotnet", ["restore", "BoardOil.slnx", "--locked-mode", "-maxcpucount:1", "-nodeReuse:false"]);
-  run("dotnet", ["build", "BoardOil.slnx", "--configuration", "Release", "--no-restore", "-maxcpucount:1", "-nodeReuse:false"]);
-  const apiTests = run("dotnet", ["BoardOil.Api.Tests/bin/Release/net10.0/BoardOil.Api.Tests.dll", ...compactTestRunnerArgs()]);
+  run("Backend restore", "dotnet", ["restore", "BoardOil.slnx", "--locked-mode", "-maxcpucount:1", "-nodeReuse:false"]);
+  run("Build backend", "dotnet", ["build", "BoardOil.slnx", "--configuration", "Release", "--no-restore", "-maxcpucount:1", "-nodeReuse:false"]);
+  const apiReportPath = profileApi
+    ? path.join(os.tmpdir(), `boardoil-api-profile-${process.pid}-${Date.now()}.xml`)
+    : null;
+  const apiTests = run("API tests", "dotnet", ["BoardOil.Api.Tests/bin/Release/net10.0/BoardOil.Api.Tests.dll", ...testRunnerArgs(apiReportPath)]);
   printDotnetTestSummary("API tests", apiTests.stdout);
+  if (apiReportPath) {
+    printApiClassProfile(apiReportPath);
+    fs.rmSync(apiReportPath, { force: true });
+  }
 
-  const devTests = run("dotnet", ["BoardOil.Dev.Tests/bin/Release/net10.0/BoardOil.Dev.Tests.dll", ...compactTestRunnerArgs()]);
+  const devTests = run("Dev orchestrator tests", "dotnet", ["BoardOil.Dev.Tests/bin/Release/net10.0/BoardOil.Dev.Tests.dll", ...testRunnerArgs()]);
   printDotnetTestSummary("Dev orchestrator tests", devTests.stdout);
 
-  const servicesTests = run("dotnet", ["BoardOil.Services.Tests/bin/Release/net10.0/BoardOil.Services.Tests.dll", ...compactTestRunnerArgs()]);
+  const servicesTests = run("Services tests", "dotnet", ["BoardOil.Services.Tests/bin/Release/net10.0/BoardOil.Services.Tests.dll", ...testRunnerArgs()]);
   printDotnetTestSummary("Services tests", servicesTests.stdout);
 }
 
 if (runWeb) {
   console.log("[test-full] Web: check + test");
-  run("npm", npmRunArgs("check"), path.join(rootDir, "BoardOil.Web"));
+  run("Web check", "npm", npmRunArgs("check"), path.join(rootDir, "BoardOil.Web"));
   if (compactOutput) {
     console.log("[test-full] Web check: passed");
   }
 
-  const webTests = run("npm", npmRunArgs("test"), path.join(rootDir, "BoardOil.Web"));
+  const webTests = run("Web tests", "npm", npmRunArgs("test"), path.join(rootDir, "BoardOil.Web"));
   printVitestSummary("Web tests", webTests.stdout);
 }
 
+printTimingSummary();
 console.log("[test-full] Done");
+
+function printTimingSummary() {
+  const timingDetails = timings
+    .map(timing => `${timing.label} ${formatElapsedTime(timing.elapsedMilliseconds)}`)
+    .join("; ");
+  console.log(`[test-full] Timing: ${formatElapsedTime(Date.now() - startedAt)} total; ${timingDetails}`);
+}
+
+function formatElapsedTime(elapsedMilliseconds) {
+  return `${(elapsedMilliseconds / 1000).toFixed(1)}s`;
+}


### PR DESCRIPTION
## What changed

- add named timing summaries to the fast and full test runners
- add optional API class-level profiling with `--profile-api`
- clone reusable, isolated SQLite templates for API and Services tests
- include migrated and bootstrapped API state in the template
- add a guard test for Services database isolation

## Why

Repeated SQLite schema creation and API database bootstrap were material contributors to local and CI test duration. The timing output also makes subsequent bottlenecks visible without ad-hoc commands.

## Measured impact

- full backend: 223.1s → 208.6s (14.5s / 6.5% faster)
- API: 198.6s → 186.0s
- Services: 27.8s → 11.1s

## Validation

- `node scripts/test-full.mjs --backend-only --compact --profile-api` — 578 tests passed
- `node scripts/test-full.mjs --web-only --compact` — 332 tests passed
- `node --check scripts/test-fast.mjs`
- `node --check scripts/test-full.mjs`
- `git diff --check`

Draft remains open while the next #729 optimisation batch is investigated.